### PR TITLE
Fix the import for the vendored pip and prepare for the v0.6.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+v0.6.0
+------
+- Add package metadata support for CocoaPods.
+- Report all PyPI package versions even if the corresponding distributions are unavailable
+- Support Python ``3.11`` and ``3.12``, drop ``3.6`` and ``3.7`` support
+- Upgrade vendored pip to 24.2 (This removes the support for pseudo vcs URLs like ``git://``,
+    ``hg://``, ``svn://`` and ``bzr://`` see https://github.com/pypa/pip/pull/9436)
+
+
 v0.5.2
 ------
 - Update link references of ownership from nexB to aboutcode-org

--- a/src/fetchcode/vcs/__init__.py
+++ b/src/fetchcode/vcs/__init__.py
@@ -65,6 +65,6 @@ def fetch_via_vcs(url):
             vcs_type = vcs_name
 
     backend = vcs.get_backend_for_scheme(scheme)
-    backend.obtain(dest=dest_dir, url=misc.hide_url(url))
+    backend.obtain(dest=dest_dir, url=misc.hide_url(url), verbosity=1)
 
     return VCSResponse(dest_dir=dest_dir, vcs_type=vcs_type, domain=domain)

--- a/src/fetchcode/vcs/pip/__init__.py
+++ b/src/fetchcode/vcs/pip/__init__.py
@@ -8,6 +8,6 @@ def main(args: Optional[List[str]] = None) -> int:
 
     For additional details, see https://github.com/pypa/pip/issues/7498.
     """
-    from pip._internal.utils.entrypoints import _wrapper
+    from fetchcode.vcs.pip._internal.utils.entrypoints import _wrapper
 
     return _wrapper(args)

--- a/src/fetchcode/vcs/pip/__main__.py
+++ b/src/fetchcode/vcs/pip/__main__.py
@@ -19,6 +19,6 @@ if __package__ == "":
     sys.path.insert(0, path)
 
 if __name__ == "__main__":
-    from pip._internal.cli.main import main as _main
+    from fetchcode.vcs.pip._internal.cli.main import main as _main
 
     sys.exit(_main())

--- a/src/fetchcode/vcs/pip/_internal/__init__.py
+++ b/src/fetchcode/vcs/pip/_internal/__init__.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pip._internal.utils import _log
+from fetchcode.vcs.pip._internal.utils import _log
 
 # init_logging() must be called before any call to logging.getLogger()
 # which happens at import of most modules.
@@ -13,6 +13,6 @@ def main(args: Optional[List[str]] = None) -> int:
 
     For additional details, see https://github.com/pypa/pip/issues/7498.
     """
-    from pip._internal.utils.entrypoints import _wrapper
+    from fetchcode.vcs.pip._internal.utils.entrypoints import _wrapper
 
     return _wrapper(args)

--- a/src/fetchcode/vcs/pip/_internal/build_env.py
+++ b/src/fetchcode/vcs/pip/_internal/build_env.py
@@ -11,20 +11,20 @@ from collections import OrderedDict
 from types import TracebackType
 from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Tuple, Type, Union
 
-from pip._vendor.certifi import where
-from pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.certifi import where
+from fetchcode.vcs.pip._vendor.packaging.version import Version
 
 from pip import __file__ as pip_location
-from pip._internal.cli.spinners import open_spinner
-from pip._internal.locations import get_platlib, get_purelib, get_scheme
-from pip._internal.metadata import get_default_environment, get_environment
-from pip._internal.utils.logging import VERBOSE
-from pip._internal.utils.packaging import get_requirement
-from pip._internal.utils.subprocess import call_subprocess
-from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
+from fetchcode.vcs.pip._internal.cli.spinners import open_spinner
+from fetchcode.vcs.pip._internal.locations import get_platlib, get_purelib, get_scheme
+from fetchcode.vcs.pip._internal.metadata import get_default_environment, get_environment
+from fetchcode.vcs.pip._internal.utils.logging import VERBOSE
+from fetchcode.vcs.pip._internal.utils.packaging import get_requirement
+from fetchcode.vcs.pip._internal.utils.subprocess import call_subprocess
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 
 if TYPE_CHECKING:
-    from pip._internal.index.package_finder import PackageFinder
+    from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/cache.py
+++ b/src/fetchcode/vcs/pip/_internal/cache.py
@@ -8,15 +8,15 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from pip._vendor.packaging.tags import Tag, interpreter_name, interpreter_version
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.tags import Tag, interpreter_name, interpreter_version
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.exceptions import InvalidWheelFilename
-from pip._internal.models.direct_url import DirectUrl
-from pip._internal.models.link import Link
-from pip._internal.models.wheel import Wheel
-from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
-from pip._internal.utils.urls import path_to_url
+from fetchcode.vcs.pip._internal.exceptions import InvalidWheelFilename
+from fetchcode.vcs.pip._internal.models.direct_url import DirectUrl
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.models.wheel import Wheel
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
+from fetchcode.vcs.pip._internal.utils.urls import path_to_url
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/cli/autocompletion.py
+++ b/src/fetchcode/vcs/pip/_internal/cli/autocompletion.py
@@ -7,9 +7,9 @@ import sys
 from itertools import chain
 from typing import Any, Iterable, List, Optional
 
-from pip._internal.cli.main_parser import create_main_parser
-from pip._internal.commands import commands_dict, create_command
-from pip._internal.metadata import get_default_environment
+from fetchcode.vcs.pip._internal.cli.main_parser import create_main_parser
+from fetchcode.vcs.pip._internal.commands import commands_dict, create_command
+from fetchcode.vcs.pip._internal.metadata import get_default_environment
 
 
 def autocomplete() -> None:

--- a/src/fetchcode/vcs/pip/_internal/cli/base_command.py
+++ b/src/fetchcode/vcs/pip/_internal/cli/base_command.py
@@ -9,19 +9,19 @@ import traceback
 from optparse import Values
 from typing import List, Optional, Tuple
 
-from pip._vendor.rich import reconfigure
-from pip._vendor.rich import traceback as rich_traceback
+from fetchcode.vcs.pip._vendor.rich import reconfigure
+from fetchcode.vcs.pip._vendor.rich import traceback as rich_traceback
 
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.command_context import CommandContextMixIn
-from pip._internal.cli.parser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
-from pip._internal.cli.status_codes import (
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.command_context import CommandContextMixIn
+from fetchcode.vcs.pip._internal.cli.parser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
+from fetchcode.vcs.pip._internal.cli.status_codes import (
     ERROR,
     PREVIOUS_BUILD_DIR_ERROR,
     UNKNOWN_ERROR,
     VIRTUALENV_NOT_FOUND,
 )
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.exceptions import (
     BadCommand,
     CommandError,
     DiagnosticPipError,
@@ -29,12 +29,12 @@ from pip._internal.exceptions import (
     NetworkConnectionError,
     PreviousBuildDirError,
 )
-from pip._internal.utils.filesystem import check_path_owner
-from pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
-from pip._internal.utils.misc import get_prog, normalize_path
-from pip._internal.utils.temp_dir import TempDirectoryTypeRegistry as TempDirRegistry
-from pip._internal.utils.temp_dir import global_tempdir_manager, tempdir_registry
-from pip._internal.utils.virtualenv import running_under_virtualenv
+from fetchcode.vcs.pip._internal.utils.filesystem import check_path_owner
+from fetchcode.vcs.pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
+from fetchcode.vcs.pip._internal.utils.misc import get_prog, normalize_path
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectoryTypeRegistry as TempDirRegistry
+from fetchcode.vcs.pip._internal.utils.temp_dir import global_tempdir_manager, tempdir_registry
+from fetchcode.vcs.pip._internal.utils.virtualenv import running_under_virtualenv
 
 __all__ = ["Command"]
 

--- a/src/fetchcode/vcs/pip/_internal/cli/cmdoptions.py
+++ b/src/fetchcode/vcs/pip/_internal/cli/cmdoptions.py
@@ -19,16 +19,16 @@ from optparse import SUPPRESS_HELP, Option, OptionGroup, OptionParser, Values
 from textwrap import dedent
 from typing import Any, Callable, Dict, Optional, Tuple
 
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.cli.parser import ConfigOptionParser
-from pip._internal.exceptions import CommandError
-from pip._internal.locations import USER_CACHE_DIR, get_src_prefix
-from pip._internal.models.format_control import FormatControl
-from pip._internal.models.index import PyPI
-from pip._internal.models.target_python import TargetPython
-from pip._internal.utils.hashes import STRONG_HASHES
-from pip._internal.utils.misc import strtobool
+from fetchcode.vcs.pip._internal.cli.parser import ConfigOptionParser
+from fetchcode.vcs.pip._internal.exceptions import CommandError
+from fetchcode.vcs.pip._internal.locations import USER_CACHE_DIR, get_src_prefix
+from fetchcode.vcs.pip._internal.models.format_control import FormatControl
+from fetchcode.vcs.pip._internal.models.index import PyPI
+from fetchcode.vcs.pip._internal.models.target_python import TargetPython
+from fetchcode.vcs.pip._internal.utils.hashes import STRONG_HASHES
+from fetchcode.vcs.pip._internal.utils.misc import strtobool
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/cli/index_command.py
+++ b/src/fetchcode/vcs/pip/_internal/cli/index_command.py
@@ -12,15 +12,15 @@ import sys
 from optparse import Values
 from typing import TYPE_CHECKING, List, Optional
 
-from pip._vendor import certifi
+from fetchcode.vcs.pip._vendor import certifi
 
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.command_context import CommandContextMixIn
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.command_context import CommandContextMixIn
 
 if TYPE_CHECKING:
     from ssl import SSLContext
 
-    from pip._internal.network.session import PipSession
+    from fetchcode.vcs.pip._internal.network.session import PipSession
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ def _create_truststore_ssl_context() -> Optional["SSLContext"]:
         return None
 
     try:
-        from pip._vendor import truststore
+        from fetchcode.vcs.pip._vendor import truststore
     except ImportError:
         logger.warning("Disabling truststore because platform isn't supported")
         return None
@@ -86,7 +86,7 @@ class SessionCommandMixin(CommandContextMixIn):
         retries: Optional[int] = None,
         timeout: Optional[int] = None,
     ) -> "PipSession":
-        from pip._internal.network.session import PipSession
+        from fetchcode.vcs.pip._internal.network.session import PipSession
 
         cache_dir = options.cache_dir
         assert not cache_dir or os.path.isabs(cache_dir)
@@ -132,7 +132,7 @@ class SessionCommandMixin(CommandContextMixIn):
 
 
 def _pip_self_version_check(session: "PipSession", options: Values) -> None:
-    from pip._internal.self_outdated_check import pip_self_version_check as check
+    from fetchcode.vcs.pip._internal.self_outdated_check import pip_self_version_check as check
 
     check(session, options)
 

--- a/src/fetchcode/vcs/pip/_internal/cli/main.py
+++ b/src/fetchcode/vcs/pip/_internal/cli/main.py
@@ -8,11 +8,11 @@ import sys
 import warnings
 from typing import List, Optional
 
-from pip._internal.cli.autocompletion import autocomplete
-from pip._internal.cli.main_parser import parse_command
-from pip._internal.commands import create_command
-from pip._internal.exceptions import PipError
-from pip._internal.utils import deprecation
+from fetchcode.vcs.pip._internal.cli.autocompletion import autocomplete
+from fetchcode.vcs.pip._internal.cli.main_parser import parse_command
+from fetchcode.vcs.pip._internal.commands import create_command
+from fetchcode.vcs.pip._internal.exceptions import PipError
+from fetchcode.vcs.pip._internal.utils import deprecation
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/cli/main_parser.py
+++ b/src/fetchcode/vcs/pip/_internal/cli/main_parser.py
@@ -6,12 +6,12 @@ import subprocess
 import sys
 from typing import List, Optional, Tuple
 
-from pip._internal.build_env import get_runnable_pip
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.parser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
-from pip._internal.commands import commands_dict, get_similar_commands
-from pip._internal.exceptions import CommandError
-from pip._internal.utils.misc import get_pip_version, get_prog
+from fetchcode.vcs.pip._internal.build_env import get_runnable_pip
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.parser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
+from fetchcode.vcs.pip._internal.commands import commands_dict, get_similar_commands
+from fetchcode.vcs.pip._internal.exceptions import CommandError
+from fetchcode.vcs.pip._internal.utils.misc import get_pip_version, get_prog
 
 __all__ = ["create_main_parser", "parse_command"]
 

--- a/src/fetchcode/vcs/pip/_internal/cli/parser.py
+++ b/src/fetchcode/vcs/pip/_internal/cli/parser.py
@@ -8,9 +8,9 @@ import textwrap
 from contextlib import suppress
 from typing import Any, Dict, Generator, List, Optional, Tuple
 
-from pip._internal.cli.status_codes import UNKNOWN_ERROR
-from pip._internal.configuration import Configuration, ConfigurationError
-from pip._internal.utils.misc import redact_auth_from_url, strtobool
+from fetchcode.vcs.pip._internal.cli.status_codes import UNKNOWN_ERROR
+from fetchcode.vcs.pip._internal.configuration import Configuration, ConfigurationError
+from fetchcode.vcs.pip._internal.utils.misc import redact_auth_from_url, strtobool
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/cli/progress_bars.py
+++ b/src/fetchcode/vcs/pip/_internal/cli/progress_bars.py
@@ -2,7 +2,7 @@ import functools
 import sys
 from typing import Callable, Generator, Iterable, Iterator, Optional, Tuple
 
-from pip._vendor.rich.progress import (
+from fetchcode.vcs.pip._vendor.rich.progress import (
     BarColumn,
     DownloadColumn,
     FileSizeColumn,
@@ -15,8 +15,8 @@ from pip._vendor.rich.progress import (
     TransferSpeedColumn,
 )
 
-from pip._internal.cli.spinners import RateLimiter
-from pip._internal.utils.logging import get_indentation
+from fetchcode.vcs.pip._internal.cli.spinners import RateLimiter
+from fetchcode.vcs.pip._internal.utils.logging import get_indentation
 
 DownloadProgressRenderer = Callable[[Iterable[bytes]], Iterator[bytes]]
 

--- a/src/fetchcode/vcs/pip/_internal/cli/req_command.py
+++ b/src/fetchcode/vcs/pip/_internal/cli/req_command.py
@@ -10,28 +10,28 @@ from functools import partial
 from optparse import Values
 from typing import Any, List, Optional, Tuple
 
-from pip._internal.cache import WheelCache
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.index_command import IndexGroupCommand
-from pip._internal.cli.index_command import SessionCommandMixin as SessionCommandMixin
-from pip._internal.exceptions import CommandError, PreviousBuildDirError
-from pip._internal.index.collector import LinkCollector
-from pip._internal.index.package_finder import PackageFinder
-from pip._internal.models.selection_prefs import SelectionPreferences
-from pip._internal.models.target_python import TargetPython
-from pip._internal.network.session import PipSession
-from pip._internal.operations.build.build_tracker import BuildTracker
-from pip._internal.operations.prepare import RequirementPreparer
-from pip._internal.req.constructors import (
+from fetchcode.vcs.pip._internal.cache import WheelCache
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.index_command import IndexGroupCommand
+from fetchcode.vcs.pip._internal.cli.index_command import SessionCommandMixin as SessionCommandMixin
+from fetchcode.vcs.pip._internal.exceptions import CommandError, PreviousBuildDirError
+from fetchcode.vcs.pip._internal.index.collector import LinkCollector
+from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
+from fetchcode.vcs.pip._internal.models.selection_prefs import SelectionPreferences
+from fetchcode.vcs.pip._internal.models.target_python import TargetPython
+from fetchcode.vcs.pip._internal.network.session import PipSession
+from fetchcode.vcs.pip._internal.operations.build.build_tracker import BuildTracker
+from fetchcode.vcs.pip._internal.operations.prepare import RequirementPreparer
+from fetchcode.vcs.pip._internal.req.constructors import (
     install_req_from_editable,
     install_req_from_line,
     install_req_from_parsed_requirement,
     install_req_from_req_string,
 )
-from pip._internal.req.req_file import parse_requirements
-from pip._internal.req.req_install import InstallRequirement
-from pip._internal.resolution.base import BaseResolver
-from pip._internal.utils.temp_dir import (
+from fetchcode.vcs.pip._internal.req.req_file import parse_requirements
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.resolution.base import BaseResolver
+from fetchcode.vcs.pip._internal.utils.temp_dir import (
     TempDirectory,
     TempDirectoryTypeRegistry,
     tempdir_kinds,

--- a/src/fetchcode/vcs/pip/_internal/cli/spinners.py
+++ b/src/fetchcode/vcs/pip/_internal/cli/spinners.py
@@ -5,8 +5,8 @@ import sys
 import time
 from typing import IO, Generator, Optional
 
-from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.logging import get_indentation
+from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
+from fetchcode.vcs.pip._internal.utils.logging import get_indentation
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/__init__.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/__init__.py
@@ -6,7 +6,7 @@ import importlib
 from collections import namedtuple
 from typing import Any, Dict, Optional
 
-from pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.base_command import Command
 
 CommandInfo = namedtuple("CommandInfo", "module_path, class_name, summary")
 

--- a/src/fetchcode/vcs/pip/_internal/commands/cache.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/cache.py
@@ -3,11 +3,11 @@ import textwrap
 from optparse import Values
 from typing import Any, List
 
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.exceptions import CommandError, PipError
-from pip._internal.utils import filesystem
-from pip._internal.utils.logging import getLogger
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.status_codes import ERROR, SUCCESS
+from fetchcode.vcs.pip._internal.exceptions import CommandError, PipError
+from fetchcode.vcs.pip._internal.utils import filesystem
+from fetchcode.vcs.pip._internal.utils.logging import getLogger
 
 logger = getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/check.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/check.py
@@ -2,16 +2,16 @@ import logging
 from optparse import Values
 from typing import List
 
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.metadata import get_default_environment
-from pip._internal.operations.check import (
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.status_codes import ERROR, SUCCESS
+from fetchcode.vcs.pip._internal.metadata import get_default_environment
+from fetchcode.vcs.pip._internal.operations.check import (
     check_package_set,
     check_unsupported,
     create_package_set_from_installed,
 )
-from pip._internal.utils.compatibility_tags import get_supported
-from pip._internal.utils.misc import write_output
+from fetchcode.vcs.pip._internal.utils.compatibility_tags import get_supported
+from fetchcode.vcs.pip._internal.utils.misc import write_output
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/completion.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/completion.py
@@ -3,9 +3,9 @@ import textwrap
 from optparse import Values
 from typing import List
 
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.utils.misc import get_prog
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.status_codes import SUCCESS
+from fetchcode.vcs.pip._internal.utils.misc import get_prog
 
 BASE_COMPLETION = """
 # pip {shell} completion start{script}# pip {shell} completion end

--- a/src/fetchcode/vcs/pip/_internal/commands/configuration.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/configuration.py
@@ -4,17 +4,17 @@ import subprocess
 from optparse import Values
 from typing import Any, List, Optional
 
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.configuration import (
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.status_codes import ERROR, SUCCESS
+from fetchcode.vcs.pip._internal.configuration import (
     Configuration,
     Kind,
     get_configuration_files,
     kinds,
 )
-from pip._internal.exceptions import PipError
-from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import get_prog, write_output
+from fetchcode.vcs.pip._internal.exceptions import PipError
+from fetchcode.vcs.pip._internal.utils.logging import indent_log
+from fetchcode.vcs.pip._internal.utils.misc import get_prog, write_output
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/debug.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/debug.py
@@ -7,18 +7,18 @@ from types import ModuleType
 from typing import Any, Dict, List, Optional
 
 import pip._vendor
-from pip._vendor.certifi import where
-from pip._vendor.packaging.version import parse as parse_version
+from fetchcode.vcs.pip._vendor.certifi import where
+from fetchcode.vcs.pip._vendor.packaging.version import parse as parse_version
 
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.cmdoptions import make_target_python
-from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.configuration import Configuration
-from pip._internal.metadata import get_environment
-from pip._internal.utils.compat import open_text_resource
-from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import get_pip_version
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.cmdoptions import make_target_python
+from fetchcode.vcs.pip._internal.cli.status_codes import SUCCESS
+from fetchcode.vcs.pip._internal.configuration import Configuration
+from fetchcode.vcs.pip._internal.metadata import get_environment
+from fetchcode.vcs.pip._internal.utils.compat import open_text_resource
+from fetchcode.vcs.pip._internal.utils.logging import indent_log
+from fetchcode.vcs.pip._internal.utils.misc import get_pip_version
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/download.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/download.py
@@ -3,14 +3,14 @@ import os
 from optparse import Values
 from typing import List
 
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.cmdoptions import make_target_python
-from pip._internal.cli.req_command import RequirementCommand, with_cleanup
-from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.operations.build.build_tracker import get_build_tracker
-from pip._internal.req.req_install import check_legacy_setup_py_options
-from pip._internal.utils.misc import ensure_dir, normalize_path, write_output
-from pip._internal.utils.temp_dir import TempDirectory
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.cmdoptions import make_target_python
+from fetchcode.vcs.pip._internal.cli.req_command import RequirementCommand, with_cleanup
+from fetchcode.vcs.pip._internal.cli.status_codes import SUCCESS
+from fetchcode.vcs.pip._internal.operations.build.build_tracker import get_build_tracker
+from fetchcode.vcs.pip._internal.req.req_install import check_legacy_setup_py_options
+from fetchcode.vcs.pip._internal.utils.misc import ensure_dir, normalize_path, write_output
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/freeze.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/freeze.py
@@ -2,11 +2,11 @@ import sys
 from optparse import Values
 from typing import AbstractSet, List
 
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.operations.freeze import freeze
-from pip._internal.utils.compat import stdlib_pkgs
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.status_codes import SUCCESS
+from fetchcode.vcs.pip._internal.operations.freeze import freeze
+from fetchcode.vcs.pip._internal.utils.compat import stdlib_pkgs
 
 
 def _should_suppress_build_backends() -> bool:

--- a/src/fetchcode/vcs/pip/_internal/commands/hash.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/hash.py
@@ -4,10 +4,10 @@ import sys
 from optparse import Values
 from typing import List
 
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.utils.hashes import FAVORITE_HASH, STRONG_HASHES
-from pip._internal.utils.misc import read_chunks, write_output
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.status_codes import ERROR, SUCCESS
+from fetchcode.vcs.pip._internal.utils.hashes import FAVORITE_HASH, STRONG_HASHES
+from fetchcode.vcs.pip._internal.utils.misc import read_chunks, write_output
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/help.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/help.py
@@ -1,9 +1,9 @@
 from optparse import Values
 from typing import List
 
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.exceptions import CommandError
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.status_codes import SUCCESS
+from fetchcode.vcs.pip._internal.exceptions import CommandError
 
 
 class HelpCommand(Command):
@@ -14,7 +14,7 @@ class HelpCommand(Command):
     ignore_require_venv = True
 
     def run(self, options: Values, args: List[str]) -> int:
-        from pip._internal.commands import (
+        from fetchcode.vcs.pip._internal.commands import (
             commands_dict,
             create_command,
             get_similar_commands,

--- a/src/fetchcode/vcs/pip/_internal/commands/index.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/index.py
@@ -2,19 +2,19 @@ import logging
 from optparse import Values
 from typing import Any, Iterable, List, Optional
 
-from pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.version import Version
 
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.req_command import IndexGroupCommand
-from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.commands.search import print_dist_installation_info
-from pip._internal.exceptions import CommandError, DistributionNotFound, PipError
-from pip._internal.index.collector import LinkCollector
-from pip._internal.index.package_finder import PackageFinder
-from pip._internal.models.selection_prefs import SelectionPreferences
-from pip._internal.models.target_python import TargetPython
-from pip._internal.network.session import PipSession
-from pip._internal.utils.misc import write_output
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.req_command import IndexGroupCommand
+from fetchcode.vcs.pip._internal.cli.status_codes import ERROR, SUCCESS
+from fetchcode.vcs.pip._internal.commands.search import print_dist_installation_info
+from fetchcode.vcs.pip._internal.exceptions import CommandError, DistributionNotFound, PipError
+from fetchcode.vcs.pip._internal.index.collector import LinkCollector
+from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
+from fetchcode.vcs.pip._internal.models.selection_prefs import SelectionPreferences
+from fetchcode.vcs.pip._internal.models.target_python import TargetPython
+from fetchcode.vcs.pip._internal.network.session import PipSession
+from fetchcode.vcs.pip._internal.utils.misc import write_output
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/inspect.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/inspect.py
@@ -2,16 +2,16 @@ import logging
 from optparse import Values
 from typing import Any, Dict, List
 
-from pip._vendor.packaging.markers import default_environment
-from pip._vendor.rich import print_json
+from fetchcode.vcs.pip._vendor.packaging.markers import default_environment
+from fetchcode.vcs.pip._vendor.rich import print_json
 
 from pip import __version__
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.metadata import BaseDistribution, get_environment
-from pip._internal.utils.compat import stdlib_pkgs
-from pip._internal.utils.urls import path_to_url
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.status_codes import SUCCESS
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution, get_environment
+from fetchcode.vcs.pip._internal.utils.compat import stdlib_pkgs
+from fetchcode.vcs.pip._internal.utils.urls import path_to_url
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/install.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/install.py
@@ -7,32 +7,32 @@ import site
 from optparse import SUPPRESS_HELP, Values
 from typing import List, Optional
 
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.rich import print_json
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.rich import print_json
 
-from pip._internal.cache import WheelCache
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.cmdoptions import make_target_python
-from pip._internal.cli.req_command import (
+from fetchcode.vcs.pip._internal.cache import WheelCache
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.cmdoptions import make_target_python
+from fetchcode.vcs.pip._internal.cli.req_command import (
     RequirementCommand,
     with_cleanup,
 )
-from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.exceptions import CommandError, InstallationError
-from pip._internal.locations import get_scheme
-from pip._internal.metadata import get_environment
-from pip._internal.models.installation_report import InstallationReport
-from pip._internal.operations.build.build_tracker import get_build_tracker
-from pip._internal.operations.check import ConflictDetails, check_install_conflicts
-from pip._internal.req import install_given_reqs
-from pip._internal.req.req_install import (
+from fetchcode.vcs.pip._internal.cli.status_codes import ERROR, SUCCESS
+from fetchcode.vcs.pip._internal.exceptions import CommandError, InstallationError
+from fetchcode.vcs.pip._internal.locations import get_scheme
+from fetchcode.vcs.pip._internal.metadata import get_environment
+from fetchcode.vcs.pip._internal.models.installation_report import InstallationReport
+from fetchcode.vcs.pip._internal.operations.build.build_tracker import get_build_tracker
+from fetchcode.vcs.pip._internal.operations.check import ConflictDetails, check_install_conflicts
+from fetchcode.vcs.pip._internal.req import install_given_reqs
+from fetchcode.vcs.pip._internal.req.req_install import (
     InstallRequirement,
     check_legacy_setup_py_options,
 )
-from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.filesystem import test_writable_dir
-from pip._internal.utils.logging import getLogger
-from pip._internal.utils.misc import (
+from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
+from fetchcode.vcs.pip._internal.utils.filesystem import test_writable_dir
+from fetchcode.vcs.pip._internal.utils.logging import getLogger
+from fetchcode.vcs.pip._internal.utils.misc import (
     check_externally_managed,
     ensure_dir,
     get_pip_version,
@@ -40,12 +40,12 @@ from pip._internal.utils.misc import (
     warn_if_run_as_root,
     write_output,
 )
-from pip._internal.utils.temp_dir import TempDirectory
-from pip._internal.utils.virtualenv import (
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory
+from fetchcode.vcs.pip._internal.utils.virtualenv import (
     running_under_virtualenv,
     virtualenv_no_global,
 )
-from pip._internal.wheel_builder import build, should_build_for_install_command
+from fetchcode.vcs.pip._internal.wheel_builder import build, should_build_for_install_command
 
 logger = getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/list.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/list.py
@@ -3,21 +3,21 @@ import logging
 from optparse import Values
 from typing import TYPE_CHECKING, Generator, List, Optional, Sequence, Tuple, cast
 
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.version import Version
 
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.index_command import IndexGroupCommand
-from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.exceptions import CommandError
-from pip._internal.metadata import BaseDistribution, get_environment
-from pip._internal.models.selection_prefs import SelectionPreferences
-from pip._internal.utils.compat import stdlib_pkgs
-from pip._internal.utils.misc import tabulate, write_output
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.index_command import IndexGroupCommand
+from fetchcode.vcs.pip._internal.cli.status_codes import SUCCESS
+from fetchcode.vcs.pip._internal.exceptions import CommandError
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution, get_environment
+from fetchcode.vcs.pip._internal.models.selection_prefs import SelectionPreferences
+from fetchcode.vcs.pip._internal.utils.compat import stdlib_pkgs
+from fetchcode.vcs.pip._internal.utils.misc import tabulate, write_output
 
 if TYPE_CHECKING:
-    from pip._internal.index.package_finder import PackageFinder
-    from pip._internal.network.session import PipSession
+    from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
+    from fetchcode.vcs.pip._internal.network.session import PipSession
 
     class _DistWithLatestInfo(BaseDistribution):
         """Give the distribution object a couple of extra fields.
@@ -145,8 +145,8 @@ class ListCommand(IndexGroupCommand):
         Create a package finder appropriate to this list command.
         """
         # Lazy import the heavy index modules as most list invocations won't need 'em.
-        from pip._internal.index.collector import LinkCollector
-        from pip._internal.index.package_finder import PackageFinder
+        from fetchcode.vcs.pip._internal.index.collector import LinkCollector
+        from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
 
         link_collector = LinkCollector.create(session, options=options)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/search.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/search.py
@@ -7,17 +7,17 @@ from collections import OrderedDict
 from optparse import Values
 from typing import TYPE_CHECKING, Dict, List, Optional, TypedDict
 
-from pip._vendor.packaging.version import parse as parse_version
+from fetchcode.vcs.pip._vendor.packaging.version import parse as parse_version
 
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.req_command import SessionCommandMixin
-from pip._internal.cli.status_codes import NO_MATCHES_FOUND, SUCCESS
-from pip._internal.exceptions import CommandError
-from pip._internal.metadata import get_default_environment
-from pip._internal.models.index import PyPI
-from pip._internal.network.xmlrpc import PipXmlrpcTransport
-from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import write_output
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.req_command import SessionCommandMixin
+from fetchcode.vcs.pip._internal.cli.status_codes import NO_MATCHES_FOUND, SUCCESS
+from fetchcode.vcs.pip._internal.exceptions import CommandError
+from fetchcode.vcs.pip._internal.metadata import get_default_environment
+from fetchcode.vcs.pip._internal.models.index import PyPI
+from fetchcode.vcs.pip._internal.network.xmlrpc import PipXmlrpcTransport
+from fetchcode.vcs.pip._internal.utils.logging import indent_log
+from fetchcode.vcs.pip._internal.utils.misc import write_output
 
 if TYPE_CHECKING:
 

--- a/src/fetchcode/vcs/pip/_internal/commands/show.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/show.py
@@ -2,13 +2,13 @@ import logging
 from optparse import Values
 from typing import Generator, Iterable, Iterator, List, NamedTuple, Optional
 
-from pip._vendor.packaging.requirements import InvalidRequirement
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.requirements import InvalidRequirement
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.metadata import BaseDistribution, get_default_environment
-from pip._internal.utils.misc import write_output
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.status_codes import ERROR, SUCCESS
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution, get_default_environment
+from fetchcode.vcs.pip._internal.utils.misc import write_output
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/commands/uninstall.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/uninstall.py
@@ -2,19 +2,19 @@ import logging
 from optparse import Values
 from typing import List
 
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.base_command import Command
-from pip._internal.cli.index_command import SessionCommandMixin
-from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.exceptions import InstallationError
-from pip._internal.req import parse_requirements
-from pip._internal.req.constructors import (
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.base_command import Command
+from fetchcode.vcs.pip._internal.cli.index_command import SessionCommandMixin
+from fetchcode.vcs.pip._internal.cli.status_codes import SUCCESS
+from fetchcode.vcs.pip._internal.exceptions import InstallationError
+from fetchcode.vcs.pip._internal.req import parse_requirements
+from fetchcode.vcs.pip._internal.req.constructors import (
     install_req_from_line,
     install_req_from_parsed_requirement,
 )
-from pip._internal.utils.misc import (
+from fetchcode.vcs.pip._internal.utils.misc import (
     check_externally_managed,
     protect_pip_from_modification_on_windows,
     warn_if_run_as_root,

--- a/src/fetchcode/vcs/pip/_internal/commands/wheel.py
+++ b/src/fetchcode/vcs/pip/_internal/commands/wheel.py
@@ -4,19 +4,19 @@ import shutil
 from optparse import Values
 from typing import List
 
-from pip._internal.cache import WheelCache
-from pip._internal.cli import cmdoptions
-from pip._internal.cli.req_command import RequirementCommand, with_cleanup
-from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.exceptions import CommandError
-from pip._internal.operations.build.build_tracker import get_build_tracker
-from pip._internal.req.req_install import (
+from fetchcode.vcs.pip._internal.cache import WheelCache
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.cli.req_command import RequirementCommand, with_cleanup
+from fetchcode.vcs.pip._internal.cli.status_codes import SUCCESS
+from fetchcode.vcs.pip._internal.exceptions import CommandError
+from fetchcode.vcs.pip._internal.operations.build.build_tracker import get_build_tracker
+from fetchcode.vcs.pip._internal.req.req_install import (
     InstallRequirement,
     check_legacy_setup_py_options,
 )
-from pip._internal.utils.misc import ensure_dir, normalize_path
-from pip._internal.utils.temp_dir import TempDirectory
-from pip._internal.wheel_builder import build, should_build_for_wheel_command
+from fetchcode.vcs.pip._internal.utils.misc import ensure_dir, normalize_path
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory
+from fetchcode.vcs.pip._internal.wheel_builder import build, should_build_for_wheel_command
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/configuration.py
+++ b/src/fetchcode/vcs/pip/_internal/configuration.py
@@ -17,14 +17,14 @@ import os
 import sys
 from typing import Any, Dict, Iterable, List, NewType, Optional, Tuple
 
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.exceptions import (
     ConfigurationError,
     ConfigurationFileCouldNotBeLoaded,
 )
-from pip._internal.utils import appdirs
-from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.logging import getLogger
-from pip._internal.utils.misc import ensure_dir, enum
+from fetchcode.vcs.pip._internal.utils import appdirs
+from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
+from fetchcode.vcs.pip._internal.utils.logging import getLogger
+from fetchcode.vcs.pip._internal.utils.misc import ensure_dir, enum
 
 RawConfigParser = configparser.RawConfigParser  # Shorthand
 Kind = NewType("Kind", str)

--- a/src/fetchcode/vcs/pip/_internal/distributions/__init__.py
+++ b/src/fetchcode/vcs/pip/_internal/distributions/__init__.py
@@ -1,7 +1,7 @@
-from pip._internal.distributions.base import AbstractDistribution
-from pip._internal.distributions.sdist import SourceDistribution
-from pip._internal.distributions.wheel import WheelDistribution
-from pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.distributions.base import AbstractDistribution
+from fetchcode.vcs.pip._internal.distributions.sdist import SourceDistribution
+from fetchcode.vcs.pip._internal.distributions.wheel import WheelDistribution
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
 
 
 def make_distribution_for_install_requirement(

--- a/src/fetchcode/vcs/pip/_internal/distributions/base.py
+++ b/src/fetchcode/vcs/pip/_internal/distributions/base.py
@@ -1,11 +1,11 @@
 import abc
 from typing import TYPE_CHECKING, Optional
 
-from pip._internal.metadata.base import BaseDistribution
-from pip._internal.req import InstallRequirement
+from fetchcode.vcs.pip._internal.metadata.base import BaseDistribution
+from fetchcode.vcs.pip._internal.req import InstallRequirement
 
 if TYPE_CHECKING:
-    from pip._internal.index.package_finder import PackageFinder
+    from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
 
 
 class AbstractDistribution(metaclass=abc.ABCMeta):

--- a/src/fetchcode/vcs/pip/_internal/distributions/installed.py
+++ b/src/fetchcode/vcs/pip/_internal/distributions/installed.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-from pip._internal.distributions.base import AbstractDistribution
-from pip._internal.index.package_finder import PackageFinder
-from pip._internal.metadata import BaseDistribution
+from fetchcode.vcs.pip._internal.distributions.base import AbstractDistribution
+from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution
 
 
 class InstalledDistribution(AbstractDistribution):

--- a/src/fetchcode/vcs/pip/_internal/distributions/sdist.py
+++ b/src/fetchcode/vcs/pip/_internal/distributions/sdist.py
@@ -1,14 +1,14 @@
 import logging
 from typing import TYPE_CHECKING, Iterable, Optional, Set, Tuple
 
-from pip._internal.build_env import BuildEnvironment
-from pip._internal.distributions.base import AbstractDistribution
-from pip._internal.exceptions import InstallationError
-from pip._internal.metadata import BaseDistribution
-from pip._internal.utils.subprocess import runner_with_spinner_message
+from fetchcode.vcs.pip._internal.build_env import BuildEnvironment
+from fetchcode.vcs.pip._internal.distributions.base import AbstractDistribution
+from fetchcode.vcs.pip._internal.exceptions import InstallationError
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution
+from fetchcode.vcs.pip._internal.utils.subprocess import runner_with_spinner_message
 
 if TYPE_CHECKING:
-    from pip._internal.index.package_finder import PackageFinder
+    from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/distributions/wheel.py
+++ b/src/fetchcode/vcs/pip/_internal/distributions/wheel.py
@@ -1,16 +1,16 @@
 from typing import TYPE_CHECKING, Optional
 
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.distributions.base import AbstractDistribution
-from pip._internal.metadata import (
+from fetchcode.vcs.pip._internal.distributions.base import AbstractDistribution
+from fetchcode.vcs.pip._internal.metadata import (
     BaseDistribution,
     FilesystemWheel,
     get_wheel_distribution,
 )
 
 if TYPE_CHECKING:
-    from pip._internal.index.package_finder import PackageFinder
+    from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
 
 
 class WheelDistribution(AbstractDistribution):

--- a/src/fetchcode/vcs/pip/_internal/exceptions.py
+++ b/src/fetchcode/vcs/pip/_internal/exceptions.py
@@ -15,17 +15,17 @@ import sys
 from itertools import chain, groupby, repeat
 from typing import TYPE_CHECKING, Dict, Iterator, List, Literal, Optional, Union
 
-from pip._vendor.rich.console import Console, ConsoleOptions, RenderResult
-from pip._vendor.rich.markup import escape
-from pip._vendor.rich.text import Text
+from fetchcode.vcs.pip._vendor.rich.console import Console, ConsoleOptions, RenderResult
+from fetchcode.vcs.pip._vendor.rich.markup import escape
+from fetchcode.vcs.pip._vendor.rich.text import Text
 
 if TYPE_CHECKING:
     from hashlib import _Hash
 
-    from pip._vendor.requests.models import Request, Response
+    from fetchcode.vcs.pip._vendor.requests.models import Request, Response
 
-    from pip._internal.metadata import BaseDistribution
-    from pip._internal.req.req_install import InstallRequirement
+    from fetchcode.vcs.pip._internal.metadata import BaseDistribution
+    from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
 
 logger = logging.getLogger(__name__)
 
@@ -539,7 +539,7 @@ class HashMissing(HashError):
 
     def body(self) -> str:
         # Dodge circular import.
-        from pip._internal.utils.hashes import FAVORITE_HASH
+        from fetchcode.vcs.pip._internal.utils.hashes import FAVORITE_HASH
 
         package = None
         if self.req:
@@ -728,7 +728,7 @@ class ExternallyManagedEnvironment(DiagnosticPipError):
         except KeyError:
             pass
         except (OSError, UnicodeDecodeError, configparser.ParsingError):
-            from pip._internal.utils._log import VERBOSE
+            from fetchcode.vcs.pip._internal.utils._log import VERBOSE
 
             exc_info = logger.isEnabledFor(VERBOSE)
             logger.warning("Failed to read %s", config, exc_info=exc_info)

--- a/src/fetchcode/vcs/pip/_internal/index/collector.py
+++ b/src/fetchcode/vcs/pip/_internal/index/collector.py
@@ -28,18 +28,18 @@ from typing import (
     Union,
 )
 
-from pip._vendor import requests
-from pip._vendor.requests import Response
-from pip._vendor.requests.exceptions import RetryError, SSLError
+from fetchcode.vcs.pip._vendor import requests
+from fetchcode.vcs.pip._vendor.requests import Response
+from fetchcode.vcs.pip._vendor.requests.exceptions import RetryError, SSLError
 
-from pip._internal.exceptions import NetworkConnectionError
-from pip._internal.models.link import Link
-from pip._internal.models.search_scope import SearchScope
-from pip._internal.network.session import PipSession
-from pip._internal.network.utils import raise_for_status
-from pip._internal.utils.filetypes import is_archive_file
-from pip._internal.utils.misc import redact_auth_from_url
-from pip._internal.vcs import vcs
+from fetchcode.vcs.pip._internal.exceptions import NetworkConnectionError
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.models.search_scope import SearchScope
+from fetchcode.vcs.pip._internal.network.session import PipSession
+from fetchcode.vcs.pip._internal.network.utils import raise_for_status
+from fetchcode.vcs.pip._internal.utils.filetypes import is_archive_file
+from fetchcode.vcs.pip._internal.utils.misc import redact_auth_from_url
+from fetchcode.vcs.pip._internal.vcs import vcs
 
 from .sources import CandidatesFromPage, LinkSource, build_source
 

--- a/src/fetchcode/vcs/pip/_internal/index/package_finder.py
+++ b/src/fetchcode/vcs/pip/_internal/index/package_finder.py
@@ -8,37 +8,37 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, FrozenSet, Iterable, List, Optional, Set, Tuple, Union
 
-from pip._vendor.packaging import specifiers
-from pip._vendor.packaging.tags import Tag
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import InvalidVersion, _BaseVersion
-from pip._vendor.packaging.version import parse as parse_version
+from fetchcode.vcs.pip._vendor.packaging import specifiers
+from fetchcode.vcs.pip._vendor.packaging.tags import Tag
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.version import InvalidVersion, _BaseVersion
+from fetchcode.vcs.pip._vendor.packaging.version import parse as parse_version
 
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.exceptions import (
     BestVersionAlreadyInstalled,
     DistributionNotFound,
     InvalidWheelFilename,
     UnsupportedWheel,
 )
-from pip._internal.index.collector import LinkCollector, parse_links
-from pip._internal.models.candidate import InstallationCandidate
-from pip._internal.models.format_control import FormatControl
-from pip._internal.models.link import Link
-from pip._internal.models.search_scope import SearchScope
-from pip._internal.models.selection_prefs import SelectionPreferences
-from pip._internal.models.target_python import TargetPython
-from pip._internal.models.wheel import Wheel
-from pip._internal.req import InstallRequirement
-from pip._internal.utils._log import getLogger
-from pip._internal.utils.filetypes import WHEEL_EXTENSION
-from pip._internal.utils.hashes import Hashes
-from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import build_netloc
-from pip._internal.utils.packaging import check_requires_python
-from pip._internal.utils.unpacking import SUPPORTED_EXTENSIONS
+from fetchcode.vcs.pip._internal.index.collector import LinkCollector, parse_links
+from fetchcode.vcs.pip._internal.models.candidate import InstallationCandidate
+from fetchcode.vcs.pip._internal.models.format_control import FormatControl
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.models.search_scope import SearchScope
+from fetchcode.vcs.pip._internal.models.selection_prefs import SelectionPreferences
+from fetchcode.vcs.pip._internal.models.target_python import TargetPython
+from fetchcode.vcs.pip._internal.models.wheel import Wheel
+from fetchcode.vcs.pip._internal.req import InstallRequirement
+from fetchcode.vcs.pip._internal.utils._log import getLogger
+from fetchcode.vcs.pip._internal.utils.filetypes import WHEEL_EXTENSION
+from fetchcode.vcs.pip._internal.utils.hashes import Hashes
+from fetchcode.vcs.pip._internal.utils.logging import indent_log
+from fetchcode.vcs.pip._internal.utils.misc import build_netloc
+from fetchcode.vcs.pip._internal.utils.packaging import check_requires_python
+from fetchcode.vcs.pip._internal.utils.unpacking import SUPPORTED_EXTENSIONS
 
 if TYPE_CHECKING:
-    from pip._vendor.typing_extensions import TypeGuard
+    from fetchcode.vcs.pip._vendor.typing_extensions import TypeGuard
 
 __all__ = ["FormatControl", "BestCandidateResult", "PackageFinder"]
 

--- a/src/fetchcode/vcs/pip/_internal/index/sources.py
+++ b/src/fetchcode/vcs/pip/_internal/index/sources.py
@@ -4,7 +4,7 @@ import os
 from collections import defaultdict
 from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
-from pip._vendor.packaging.utils import (
+from fetchcode.vcs.pip._vendor.packaging.utils import (
     InvalidSdistFilename,
     InvalidVersion,
     InvalidWheelFilename,
@@ -13,10 +13,10 @@ from pip._vendor.packaging.utils import (
     parse_wheel_filename,
 )
 
-from pip._internal.models.candidate import InstallationCandidate
-from pip._internal.models.link import Link
-from pip._internal.utils.urls import path_to_url, url_to_path
-from pip._internal.vcs import is_url
+from fetchcode.vcs.pip._internal.models.candidate import InstallationCandidate
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.utils.urls import path_to_url, url_to_path
+from fetchcode.vcs.pip._internal.vcs import is_url
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/locations/__init__.py
+++ b/src/fetchcode/vcs/pip/_internal/locations/__init__.py
@@ -6,10 +6,10 @@ import sys
 import sysconfig
 from typing import Any, Dict, Generator, Optional, Tuple
 
-from pip._internal.models.scheme import SCHEME_KEYS, Scheme
-from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.deprecation import deprecated
-from pip._internal.utils.virtualenv import running_under_virtualenv
+from fetchcode.vcs.pip._internal.models.scheme import SCHEME_KEYS, Scheme
+from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
+from fetchcode.vcs.pip._internal.utils.deprecation import deprecated
+from fetchcode.vcs.pip._internal.utils.virtualenv import running_under_virtualenv
 
 from . import _sysconfig
 from .base import (

--- a/src/fetchcode/vcs/pip/_internal/locations/_distutils.py
+++ b/src/fetchcode/vcs/pip/_internal/locations/_distutils.py
@@ -23,9 +23,9 @@ from distutils.command.install import install as distutils_install_command
 from distutils.sysconfig import get_python_lib
 from typing import Dict, List, Optional, Union, cast
 
-from pip._internal.models.scheme import Scheme
-from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.virtualenv import running_under_virtualenv
+from fetchcode.vcs.pip._internal.models.scheme import Scheme
+from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
+from fetchcode.vcs.pip._internal.utils.virtualenv import running_under_virtualenv
 
 from .base import get_major_minor_version
 

--- a/src/fetchcode/vcs/pip/_internal/locations/_sysconfig.py
+++ b/src/fetchcode/vcs/pip/_internal/locations/_sysconfig.py
@@ -4,9 +4,9 @@ import sys
 import sysconfig
 import typing
 
-from pip._internal.exceptions import InvalidSchemeCombination, UserInstallationInvalid
-from pip._internal.models.scheme import SCHEME_KEYS, Scheme
-from pip._internal.utils.virtualenv import running_under_virtualenv
+from fetchcode.vcs.pip._internal.exceptions import InvalidSchemeCombination, UserInstallationInvalid
+from fetchcode.vcs.pip._internal.models.scheme import SCHEME_KEYS, Scheme
+from fetchcode.vcs.pip._internal.utils.virtualenv import running_under_virtualenv
 
 from .base import change_root, get_major_minor_version, is_osx_framework
 

--- a/src/fetchcode/vcs/pip/_internal/locations/base.py
+++ b/src/fetchcode/vcs/pip/_internal/locations/base.py
@@ -5,9 +5,9 @@ import sys
 import sysconfig
 import typing
 
-from pip._internal.exceptions import InstallationError
-from pip._internal.utils import appdirs
-from pip._internal.utils.virtualenv import running_under_virtualenv
+from fetchcode.vcs.pip._internal.exceptions import InstallationError
+from fetchcode.vcs.pip._internal.utils import appdirs
+from fetchcode.vcs.pip._internal.utils.virtualenv import running_under_virtualenv
 
 # Application Directories
 USER_CACHE_DIR = appdirs.user_cache_dir("pip")

--- a/src/fetchcode/vcs/pip/_internal/main.py
+++ b/src/fetchcode/vcs/pip/_internal/main.py
@@ -7,6 +7,6 @@ def main(args: Optional[List[str]] = None) -> int:
 
     For additional details, see https://github.com/pypa/pip/issues/7498.
     """
-    from pip._internal.utils.entrypoints import _wrapper
+    from fetchcode.vcs.pip._internal.utils.entrypoints import _wrapper
 
     return _wrapper(args)

--- a/src/fetchcode/vcs/pip/_internal/metadata/__init__.py
+++ b/src/fetchcode/vcs/pip/_internal/metadata/__init__.py
@@ -4,7 +4,7 @@ import os
 import sys
 from typing import TYPE_CHECKING, List, Optional, Type, cast
 
-from pip._internal.utils.misc import strtobool
+from fetchcode.vcs.pip._internal.utils.misc import strtobool
 
 from .base import BaseDistribution, BaseEnvironment, FilesystemWheel, MemoryWheel, Wheel
 

--- a/src/fetchcode/vcs/pip/_internal/metadata/base.py
+++ b/src/fetchcode/vcs/pip/_internal/metadata/base.py
@@ -22,22 +22,22 @@ from typing import (
     Union,
 )
 
-from pip._vendor.packaging.requirements import Requirement
-from pip._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
-from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
-from pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.requirements import Requirement
+from fetchcode.vcs.pip._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
+from fetchcode.vcs.pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.version import Version
 
-from pip._internal.exceptions import NoneMetadataError
-from pip._internal.locations import site_packages, user_site
-from pip._internal.models.direct_url import (
+from fetchcode.vcs.pip._internal.exceptions import NoneMetadataError
+from fetchcode.vcs.pip._internal.locations import site_packages, user_site
+from fetchcode.vcs.pip._internal.models.direct_url import (
     DIRECT_URL_METADATA_NAME,
     DirectUrl,
     DirectUrlValidationError,
 )
-from pip._internal.utils.compat import stdlib_pkgs  # TODO: Move definition here.
-from pip._internal.utils.egg_link import egg_link_path_from_sys_path
-from pip._internal.utils.misc import is_local, normalize_path
-from pip._internal.utils.urls import url_to_path
+from fetchcode.vcs.pip._internal.utils.compat import stdlib_pkgs  # TODO: Move definition here.
+from fetchcode.vcs.pip._internal.utils.egg_link import egg_link_path_from_sys_path
+from fetchcode.vcs.pip._internal.utils.misc import is_local, normalize_path
+from fetchcode.vcs.pip._internal.utils.urls import url_to_path
 
 from ._json import msg_to_json
 

--- a/src/fetchcode/vcs/pip/_internal/metadata/importlib/_compat.py
+++ b/src/fetchcode/vcs/pip/_internal/metadata/importlib/_compat.py
@@ -2,7 +2,7 @@ import importlib.metadata
 import os
 from typing import Any, Optional, Protocol, Tuple, cast
 
-from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 
 
 class BadMetadata(ValueError):

--- a/src/fetchcode/vcs/pip/_internal/metadata/importlib/_dists.py
+++ b/src/fetchcode/vcs/pip/_internal/metadata/importlib/_dists.py
@@ -13,22 +13,22 @@ from typing import (
     cast,
 )
 
-from pip._vendor.packaging.requirements import Requirement
-from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
-from pip._vendor.packaging.version import Version
-from pip._vendor.packaging.version import parse as parse_version
+from fetchcode.vcs.pip._vendor.packaging.requirements import Requirement
+from fetchcode.vcs.pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.version import parse as parse_version
 
-from pip._internal.exceptions import InvalidWheel, UnsupportedWheel
-from pip._internal.metadata.base import (
+from fetchcode.vcs.pip._internal.exceptions import InvalidWheel, UnsupportedWheel
+from fetchcode.vcs.pip._internal.metadata.base import (
     BaseDistribution,
     BaseEntryPoint,
     InfoPath,
     Wheel,
 )
-from pip._internal.utils.misc import normalize_path
-from pip._internal.utils.packaging import get_requirement
-from pip._internal.utils.temp_dir import TempDirectory
-from pip._internal.utils.wheel import parse_wheel, read_wheel_metadata_file
+from fetchcode.vcs.pip._internal.utils.misc import normalize_path
+from fetchcode.vcs.pip._internal.utils.packaging import get_requirement
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory
+from fetchcode.vcs.pip._internal.utils.wheel import parse_wheel, read_wheel_metadata_file
 
 from ._compat import (
     BasePath,

--- a/src/fetchcode/vcs/pip/_internal/metadata/importlib/_envs.py
+++ b/src/fetchcode/vcs/pip/_internal/metadata/importlib/_envs.py
@@ -8,12 +8,12 @@ import zipfile
 import zipimport
 from typing import Iterator, List, Optional, Sequence, Set, Tuple
 
-from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 
-from pip._internal.metadata.base import BaseDistribution, BaseEnvironment
-from pip._internal.models.wheel import Wheel
-from pip._internal.utils.deprecation import deprecated
-from pip._internal.utils.filetypes import WHEEL_EXTENSION
+from fetchcode.vcs.pip._internal.metadata.base import BaseDistribution, BaseEnvironment
+from fetchcode.vcs.pip._internal.models.wheel import Wheel
+from fetchcode.vcs.pip._internal.utils.deprecation import deprecated
+from fetchcode.vcs.pip._internal.utils.filetypes import WHEEL_EXTENSION
 
 from ._compat import BadMetadata, BasePath, get_dist_canonical_name, get_info_location
 from ._dists import Distribution
@@ -107,9 +107,9 @@ class _DistributionFinder:
                 yield Distribution(dist, info_location, path)
 
     def _find_eggs_in_dir(self, location: str) -> Iterator[BaseDistribution]:
-        from pip._vendor.pkg_resources import find_distributions
+        from fetchcode.vcs.pip._vendor.pkg_resources import find_distributions
 
-        from pip._internal.metadata import pkg_resources as legacy
+        from fetchcode.vcs.pip._internal.metadata import pkg_resources as legacy
 
         with os.scandir(location) as it:
             for entry in it:
@@ -119,9 +119,9 @@ class _DistributionFinder:
                     yield legacy.Distribution(dist)
 
     def _find_eggs_in_zip(self, location: str) -> Iterator[BaseDistribution]:
-        from pip._vendor.pkg_resources import find_eggs_in_zip
+        from fetchcode.vcs.pip._vendor.pkg_resources import find_eggs_in_zip
 
-        from pip._internal.metadata import pkg_resources as legacy
+        from fetchcode.vcs.pip._internal.metadata import pkg_resources as legacy
 
         try:
             importer = zipimport.zipimporter(location)

--- a/src/fetchcode/vcs/pip/_internal/metadata/pkg_resources.py
+++ b/src/fetchcode/vcs/pip/_internal/metadata/pkg_resources.py
@@ -13,16 +13,16 @@ from typing import (
     Optional,
 )
 
-from pip._vendor import pkg_resources
-from pip._vendor.packaging.requirements import Requirement
-from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
-from pip._vendor.packaging.version import Version
-from pip._vendor.packaging.version import parse as parse_version
+from fetchcode.vcs.pip._vendor import pkg_resources
+from fetchcode.vcs.pip._vendor.packaging.requirements import Requirement
+from fetchcode.vcs.pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.version import parse as parse_version
 
-from pip._internal.exceptions import InvalidWheel, NoneMetadataError, UnsupportedWheel
-from pip._internal.utils.egg_link import egg_link_path_from_location
-from pip._internal.utils.misc import display_path, normalize_path
-from pip._internal.utils.wheel import parse_wheel, read_wheel_metadata_file
+from fetchcode.vcs.pip._internal.exceptions import InvalidWheel, NoneMetadataError, UnsupportedWheel
+from fetchcode.vcs.pip._internal.utils.egg_link import egg_link_path_from_location
+from fetchcode.vcs.pip._internal.utils.misc import display_path, normalize_path
+from fetchcode.vcs.pip._internal.utils.wheel import parse_wheel, read_wheel_metadata_file
 
 from .base import (
     BaseDistribution,

--- a/src/fetchcode/vcs/pip/_internal/models/candidate.py
+++ b/src/fetchcode/vcs/pip/_internal/models/candidate.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 
-from pip._vendor.packaging.version import Version
-from pip._vendor.packaging.version import parse as parse_version
+from fetchcode.vcs.pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.version import parse as parse_version
 
-from pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.models.link import Link
 
 
 @dataclass(frozen=True)

--- a/src/fetchcode/vcs/pip/_internal/models/format_control.py
+++ b/src/fetchcode/vcs/pip/_internal/models/format_control.py
@@ -1,8 +1,8 @@
 from typing import FrozenSet, Optional, Set
 
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.exceptions import CommandError
+from fetchcode.vcs.pip._internal.exceptions import CommandError
 
 
 class FormatControl:

--- a/src/fetchcode/vcs/pip/_internal/models/installation_report.py
+++ b/src/fetchcode/vcs/pip/_internal/models/installation_report.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Sequence
 
-from pip._vendor.packaging.markers import default_environment
+from fetchcode.vcs.pip._vendor.packaging.markers import default_environment
 
 from pip import __version__
-from pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
 
 
 class InstallationReport:

--- a/src/fetchcode/vcs/pip/_internal/models/link.py
+++ b/src/fetchcode/vcs/pip/_internal/models/link.py
@@ -18,19 +18,19 @@ from typing import (
     Union,
 )
 
-from pip._internal.utils.deprecation import deprecated
-from pip._internal.utils.filetypes import WHEEL_EXTENSION
-from pip._internal.utils.hashes import Hashes
-from pip._internal.utils.misc import (
+from fetchcode.vcs.pip._internal.utils.deprecation import deprecated
+from fetchcode.vcs.pip._internal.utils.filetypes import WHEEL_EXTENSION
+from fetchcode.vcs.pip._internal.utils.hashes import Hashes
+from fetchcode.vcs.pip._internal.utils.misc import (
     pairwise,
     redact_auth_from_url,
     split_auth_from_netloc,
     splitext,
 )
-from pip._internal.utils.urls import path_to_url, url_to_path
+from fetchcode.vcs.pip._internal.utils.urls import path_to_url, url_to_path
 
 if TYPE_CHECKING:
-    from pip._internal.index.collector import IndexContent
+    from fetchcode.vcs.pip._internal.index.collector import IndexContent
 
 logger = logging.getLogger(__name__)
 
@@ -506,7 +506,7 @@ class Link:
 
     @property
     def is_vcs(self) -> bool:
-        from pip._internal.vcs import vcs
+        from fetchcode.vcs.pip._internal.vcs import vcs
 
         return self.scheme in vcs.all_schemes
 

--- a/src/fetchcode/vcs/pip/_internal/models/search_scope.py
+++ b/src/fetchcode/vcs/pip/_internal/models/search_scope.py
@@ -6,11 +6,11 @@ import urllib.parse
 from dataclasses import dataclass
 from typing import List
 
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.models.index import PyPI
-from pip._internal.utils.compat import has_tls
-from pip._internal.utils.misc import normalize_path, redact_auth_from_url
+from fetchcode.vcs.pip._internal.models.index import PyPI
+from fetchcode.vcs.pip._internal.utils.compat import has_tls
+from fetchcode.vcs.pip._internal.utils.misc import normalize_path, redact_auth_from_url
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/models/selection_prefs.py
+++ b/src/fetchcode/vcs/pip/_internal/models/selection_prefs.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pip._internal.models.format_control import FormatControl
+from fetchcode.vcs.pip._internal.models.format_control import FormatControl
 
 
 # TODO: This needs Python 3.10's improved slots support for dataclasses

--- a/src/fetchcode/vcs/pip/_internal/models/target_python.py
+++ b/src/fetchcode/vcs/pip/_internal/models/target_python.py
@@ -1,10 +1,10 @@
 import sys
 from typing import List, Optional, Set, Tuple
 
-from pip._vendor.packaging.tags import Tag
+from fetchcode.vcs.pip._vendor.packaging.tags import Tag
 
-from pip._internal.utils.compatibility_tags import get_supported, version_info_to_nodot
-from pip._internal.utils.misc import normalize_version_info
+from fetchcode.vcs.pip._internal.utils.compatibility_tags import get_supported, version_info_to_nodot
+from fetchcode.vcs.pip._internal.utils.misc import normalize_version_info
 
 
 class TargetPython:

--- a/src/fetchcode/vcs/pip/_internal/models/wheel.py
+++ b/src/fetchcode/vcs/pip/_internal/models/wheel.py
@@ -5,9 +5,9 @@ name that have meaning.
 import re
 from typing import Dict, Iterable, List
 
-from pip._vendor.packaging.tags import Tag
+from fetchcode.vcs.pip._vendor.packaging.tags import Tag
 
-from pip._internal.exceptions import InvalidWheelFilename
+from fetchcode.vcs.pip._internal.exceptions import InvalidWheelFilename
 
 
 class Wheel:

--- a/src/fetchcode/vcs/pip/_internal/network/auth.py
+++ b/src/fetchcode/vcs/pip/_internal/network/auth.py
@@ -17,19 +17,19 @@ from os.path import commonprefix
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
-from pip._vendor.requests.auth import AuthBase, HTTPBasicAuth
-from pip._vendor.requests.models import Request, Response
-from pip._vendor.requests.utils import get_netrc_auth
+from fetchcode.vcs.pip._vendor.requests.auth import AuthBase, HTTPBasicAuth
+from fetchcode.vcs.pip._vendor.requests.models import Request, Response
+from fetchcode.vcs.pip._vendor.requests.utils import get_netrc_auth
 
-from pip._internal.utils.logging import getLogger
-from pip._internal.utils.misc import (
+from fetchcode.vcs.pip._internal.utils.logging import getLogger
+from fetchcode.vcs.pip._internal.utils.misc import (
     ask,
     ask_input,
     ask_password,
     remove_auth_from_url,
     split_auth_netloc_from_url,
 )
-from pip._internal.vcs.versioncontrol import AuthInfo
+from fetchcode.vcs.pip._internal.vcs.versioncontrol import AuthInfo
 
 logger = getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/network/cache.py
+++ b/src/fetchcode/vcs/pip/_internal/network/cache.py
@@ -6,12 +6,12 @@ from contextlib import contextmanager
 from datetime import datetime
 from typing import BinaryIO, Generator, Optional, Union
 
-from pip._vendor.cachecontrol.cache import SeparateBodyBaseCache
-from pip._vendor.cachecontrol.caches import SeparateBodyFileCache
-from pip._vendor.requests.models import Response
+from fetchcode.vcs.pip._vendor.cachecontrol.cache import SeparateBodyBaseCache
+from fetchcode.vcs.pip._vendor.cachecontrol.caches import SeparateBodyFileCache
+from fetchcode.vcs.pip._vendor.requests.models import Response
 
-from pip._internal.utils.filesystem import adjacent_tmp_file, replace
-from pip._internal.utils.misc import ensure_dir
+from fetchcode.vcs.pip._internal.utils.filesystem import adjacent_tmp_file, replace
+from fetchcode.vcs.pip._internal.utils.misc import ensure_dir
 
 
 def is_from_cache(response: Response) -> bool:

--- a/src/fetchcode/vcs/pip/_internal/network/download.py
+++ b/src/fetchcode/vcs/pip/_internal/network/download.py
@@ -7,16 +7,16 @@ import mimetypes
 import os
 from typing import Iterable, Optional, Tuple
 
-from pip._vendor.requests.models import Response
+from fetchcode.vcs.pip._vendor.requests.models import Response
 
-from pip._internal.cli.progress_bars import get_download_progress_renderer
-from pip._internal.exceptions import NetworkConnectionError
-from pip._internal.models.index import PyPI
-from pip._internal.models.link import Link
-from pip._internal.network.cache import is_from_cache
-from pip._internal.network.session import PipSession
-from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
-from pip._internal.utils.misc import format_size, redact_auth_from_url, splitext
+from fetchcode.vcs.pip._internal.cli.progress_bars import get_download_progress_renderer
+from fetchcode.vcs.pip._internal.exceptions import NetworkConnectionError
+from fetchcode.vcs.pip._internal.models.index import PyPI
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.network.cache import is_from_cache
+from fetchcode.vcs.pip._internal.network.session import PipSession
+from fetchcode.vcs.pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
+from fetchcode.vcs.pip._internal.utils.misc import format_size, redact_auth_from_url, splitext
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/network/lazy_wheel.py
+++ b/src/fetchcode/vcs/pip/_internal/network/lazy_wheel.py
@@ -8,12 +8,12 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Generator, List, Optional, Tuple
 from zipfile import BadZipFile, ZipFile
 
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
 
-from pip._internal.metadata import BaseDistribution, MemoryWheel, get_wheel_distribution
-from pip._internal.network.session import PipSession
-from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution, MemoryWheel, get_wheel_distribution
+from fetchcode.vcs.pip._internal.network.session import PipSession
+from fetchcode.vcs.pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
 
 
 class HTTPRangeRequestUnsupported(Exception):

--- a/src/fetchcode/vcs/pip/_internal/network/session.py
+++ b/src/fetchcode/vcs/pip/_internal/network/session.py
@@ -29,31 +29,31 @@ from typing import (
     Union,
 )
 
-from pip._vendor import requests, urllib3
-from pip._vendor.cachecontrol import CacheControlAdapter as _BaseCacheControlAdapter
-from pip._vendor.requests.adapters import DEFAULT_POOLBLOCK, BaseAdapter
-from pip._vendor.requests.adapters import HTTPAdapter as _BaseHTTPAdapter
-from pip._vendor.requests.models import PreparedRequest, Response
-from pip._vendor.requests.structures import CaseInsensitiveDict
-from pip._vendor.urllib3.connectionpool import ConnectionPool
-from pip._vendor.urllib3.exceptions import InsecureRequestWarning
+from fetchcode.vcs.pip._vendor import requests, urllib3
+from fetchcode.vcs.pip._vendor.cachecontrol import CacheControlAdapter as _BaseCacheControlAdapter
+from fetchcode.vcs.pip._vendor.requests.adapters import DEFAULT_POOLBLOCK, BaseAdapter
+from fetchcode.vcs.pip._vendor.requests.adapters import HTTPAdapter as _BaseHTTPAdapter
+from fetchcode.vcs.pip._vendor.requests.models import PreparedRequest, Response
+from fetchcode.vcs.pip._vendor.requests.structures import CaseInsensitiveDict
+from fetchcode.vcs.pip._vendor.urllib3.connectionpool import ConnectionPool
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import InsecureRequestWarning
 
 from pip import __version__
-from pip._internal.metadata import get_default_environment
-from pip._internal.models.link import Link
-from pip._internal.network.auth import MultiDomainBasicAuth
-from pip._internal.network.cache import SafeFileCache
+from fetchcode.vcs.pip._internal.metadata import get_default_environment
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.network.auth import MultiDomainBasicAuth
+from fetchcode.vcs.pip._internal.network.cache import SafeFileCache
 
 # Import ssl from compat so the initial import occurs in only one place.
-from pip._internal.utils.compat import has_tls
-from pip._internal.utils.glibc import libc_ver
-from pip._internal.utils.misc import build_url_from_netloc, parse_netloc
-from pip._internal.utils.urls import url_to_path
+from fetchcode.vcs.pip._internal.utils.compat import has_tls
+from fetchcode.vcs.pip._internal.utils.glibc import libc_ver
+from fetchcode.vcs.pip._internal.utils.misc import build_url_from_netloc, parse_netloc
+from fetchcode.vcs.pip._internal.utils.urls import url_to_path
 
 if TYPE_CHECKING:
     from ssl import SSLContext
 
-    from pip._vendor.urllib3.poolmanager import PoolManager
+    from fetchcode.vcs.pip._vendor.urllib3.poolmanager import PoolManager
 
 
 logger = logging.getLogger(__name__)
@@ -137,7 +137,7 @@ def user_agent() -> str:
         data["implementation"]["version"] = platform.python_version()
 
     if sys.platform.startswith("linux"):
-        from pip._vendor import distro
+        from fetchcode.vcs.pip._vendor import distro
 
         linux_distribution = distro.name(), distro.version(), distro.codename()
         distro_infos: Dict[str, Any] = dict(

--- a/src/fetchcode/vcs/pip/_internal/network/utils.py
+++ b/src/fetchcode/vcs/pip/_internal/network/utils.py
@@ -1,8 +1,8 @@
 from typing import Dict, Generator
 
-from pip._vendor.requests.models import Response
+from fetchcode.vcs.pip._vendor.requests.models import Response
 
-from pip._internal.exceptions import NetworkConnectionError
+from fetchcode.vcs.pip._internal.exceptions import NetworkConnectionError
 
 # The following comments and HTTP headers were originally added by
 # Donald Stufft in git commit 22c562429a61bb77172039e480873fb239dd8c03.

--- a/src/fetchcode/vcs/pip/_internal/network/xmlrpc.py
+++ b/src/fetchcode/vcs/pip/_internal/network/xmlrpc.py
@@ -6,9 +6,9 @@ import urllib.parse
 import xmlrpc.client
 from typing import TYPE_CHECKING, Tuple
 
-from pip._internal.exceptions import NetworkConnectionError
-from pip._internal.network.session import PipSession
-from pip._internal.network.utils import raise_for_status
+from fetchcode.vcs.pip._internal.exceptions import NetworkConnectionError
+from fetchcode.vcs.pip._internal.network.session import PipSession
+from fetchcode.vcs.pip._internal.network.utils import raise_for_status
 
 if TYPE_CHECKING:
     from xmlrpc.client import _HostType, _Marshallable

--- a/src/fetchcode/vcs/pip/_internal/operations/build/build_tracker.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/build/build_tracker.py
@@ -5,8 +5,8 @@ import os
 from types import TracebackType
 from typing import Dict, Generator, Optional, Type, Union
 
-from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.temp_dir import TempDirectory
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/operations/build/metadata.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/build/metadata.py
@@ -3,15 +3,15 @@
 
 import os
 
-from pip._vendor.pyproject_hooks import BuildBackendHookCaller
+from fetchcode.vcs.pip._vendor.pyproject_hooks import BuildBackendHookCaller
 
-from pip._internal.build_env import BuildEnvironment
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.build_env import BuildEnvironment
+from fetchcode.vcs.pip._internal.exceptions import (
     InstallationSubprocessError,
     MetadataGenerationFailed,
 )
-from pip._internal.utils.subprocess import runner_with_spinner_message
-from pip._internal.utils.temp_dir import TempDirectory
+from fetchcode.vcs.pip._internal.utils.subprocess import runner_with_spinner_message
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory
 
 
 def generate_metadata(

--- a/src/fetchcode/vcs/pip/_internal/operations/build/metadata_editable.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/build/metadata_editable.py
@@ -3,15 +3,15 @@
 
 import os
 
-from pip._vendor.pyproject_hooks import BuildBackendHookCaller
+from fetchcode.vcs.pip._vendor.pyproject_hooks import BuildBackendHookCaller
 
-from pip._internal.build_env import BuildEnvironment
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.build_env import BuildEnvironment
+from fetchcode.vcs.pip._internal.exceptions import (
     InstallationSubprocessError,
     MetadataGenerationFailed,
 )
-from pip._internal.utils.subprocess import runner_with_spinner_message
-from pip._internal.utils.temp_dir import TempDirectory
+from fetchcode.vcs.pip._internal.utils.subprocess import runner_with_spinner_message
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory
 
 
 def generate_editable_metadata(

--- a/src/fetchcode/vcs/pip/_internal/operations/build/metadata_legacy.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/build/metadata_legacy.py
@@ -4,16 +4,16 @@
 import logging
 import os
 
-from pip._internal.build_env import BuildEnvironment
-from pip._internal.cli.spinners import open_spinner
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.build_env import BuildEnvironment
+from fetchcode.vcs.pip._internal.cli.spinners import open_spinner
+from fetchcode.vcs.pip._internal.exceptions import (
     InstallationError,
     InstallationSubprocessError,
     MetadataGenerationFailed,
 )
-from pip._internal.utils.setuptools_build import make_setuptools_egg_info_args
-from pip._internal.utils.subprocess import call_subprocess
-from pip._internal.utils.temp_dir import TempDirectory
+from fetchcode.vcs.pip._internal.utils.setuptools_build import make_setuptools_egg_info_args
+from fetchcode.vcs.pip._internal.utils.subprocess import call_subprocess
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/operations/build/wheel.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/build/wheel.py
@@ -2,9 +2,9 @@ import logging
 import os
 from typing import Optional
 
-from pip._vendor.pyproject_hooks import BuildBackendHookCaller
+from fetchcode.vcs.pip._vendor.pyproject_hooks import BuildBackendHookCaller
 
-from pip._internal.utils.subprocess import runner_with_spinner_message
+from fetchcode.vcs.pip._internal.utils.subprocess import runner_with_spinner_message
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/operations/build/wheel_editable.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/build/wheel_editable.py
@@ -2,9 +2,9 @@ import logging
 import os
 from typing import Optional
 
-from pip._vendor.pyproject_hooks import BuildBackendHookCaller, HookMissing
+from fetchcode.vcs.pip._vendor.pyproject_hooks import BuildBackendHookCaller, HookMissing
 
-from pip._internal.utils.subprocess import runner_with_spinner_message
+from fetchcode.vcs.pip._internal.utils.subprocess import runner_with_spinner_message
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/operations/build/wheel_legacy.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/build/wheel_legacy.py
@@ -2,9 +2,9 @@ import logging
 import os.path
 from typing import List, Optional
 
-from pip._internal.cli.spinners import open_spinner
-from pip._internal.utils.setuptools_build import make_setuptools_bdist_wheel_args
-from pip._internal.utils.subprocess import call_subprocess, format_command_args
+from fetchcode.vcs.pip._internal.cli.spinners import open_spinner
+from fetchcode.vcs.pip._internal.utils.setuptools_build import make_setuptools_bdist_wheel_args
+from fetchcode.vcs.pip._internal.utils.subprocess import call_subprocess, format_command_args
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/operations/check.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/check.py
@@ -18,15 +18,15 @@ from typing import (
     Tuple,
 )
 
-from pip._vendor.packaging.requirements import Requirement
-from pip._vendor.packaging.tags import Tag, parse_tag
-from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
-from pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.requirements import Requirement
+from fetchcode.vcs.pip._vendor.packaging.tags import Tag, parse_tag
+from fetchcode.vcs.pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.version import Version
 
-from pip._internal.distributions import make_distribution_for_install_requirement
-from pip._internal.metadata import get_default_environment
-from pip._internal.metadata.base import BaseDistribution
-from pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.distributions import make_distribution_for_install_requirement
+from fetchcode.vcs.pip._internal.metadata import get_default_environment
+from fetchcode.vcs.pip._internal.metadata.base import BaseDistribution
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/operations/freeze.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/freeze.py
@@ -3,17 +3,17 @@ import logging
 import os
 from typing import Container, Dict, Generator, Iterable, List, NamedTuple, Optional, Set
 
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import InvalidVersion
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.version import InvalidVersion
 
-from pip._internal.exceptions import BadCommand, InstallationError
-from pip._internal.metadata import BaseDistribution, get_environment
-from pip._internal.req.constructors import (
+from fetchcode.vcs.pip._internal.exceptions import BadCommand, InstallationError
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution, get_environment
+from fetchcode.vcs.pip._internal.req.constructors import (
     install_req_from_editable,
     install_req_from_line,
 )
-from pip._internal.req.req_file import COMMENT_RE
-from pip._internal.utils.direct_url_helpers import direct_url_as_pep440_direct_reference
+from fetchcode.vcs.pip._internal.req.req_file import COMMENT_RE
+from fetchcode.vcs.pip._internal.utils.direct_url_helpers import direct_url_as_pep440_direct_reference
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +163,7 @@ def _get_editable_info(dist: BaseDistribution) -> _EditableInfo:
     assert editable_project_location
     location = os.path.normcase(os.path.abspath(editable_project_location))
 
-    from pip._internal.vcs import RemoteNotFoundError, RemoteNotValidError, vcs
+    from fetchcode.vcs.pip._internal.vcs import RemoteNotFoundError, RemoteNotValidError, vcs
 
     vcs_backend = vcs.get_backend_for_dir(location)
 

--- a/src/fetchcode/vcs/pip/_internal/operations/install/editable_legacy.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/install/editable_legacy.py
@@ -4,10 +4,10 @@
 import logging
 from typing import Optional, Sequence
 
-from pip._internal.build_env import BuildEnvironment
-from pip._internal.utils.logging import indent_log
-from pip._internal.utils.setuptools_build import make_setuptools_develop_args
-from pip._internal.utils.subprocess import call_subprocess
+from fetchcode.vcs.pip._internal.build_env import BuildEnvironment
+from fetchcode.vcs.pip._internal.utils.logging import indent_log
+from fetchcode.vcs.pip._internal.utils.setuptools_build import make_setuptools_develop_args
+from fetchcode.vcs.pip._internal.utils.subprocess import call_subprocess
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/operations/install/wheel.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/install/wheel.py
@@ -37,28 +37,28 @@ from typing import (
 )
 from zipfile import ZipFile, ZipInfo
 
-from pip._vendor.distlib.scripts import ScriptMaker
-from pip._vendor.distlib.util import get_export_entry
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.distlib.scripts import ScriptMaker
+from fetchcode.vcs.pip._vendor.distlib.util import get_export_entry
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.exceptions import InstallationError
-from pip._internal.locations import get_major_minor_version
-from pip._internal.metadata import (
+from fetchcode.vcs.pip._internal.exceptions import InstallationError
+from fetchcode.vcs.pip._internal.locations import get_major_minor_version
+from fetchcode.vcs.pip._internal.metadata import (
     BaseDistribution,
     FilesystemWheel,
     get_wheel_distribution,
 )
-from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
-from pip._internal.models.scheme import SCHEME_KEYS, Scheme
-from pip._internal.utils.filesystem import adjacent_tmp_file, replace
-from pip._internal.utils.misc import StreamWrapper, ensure_dir, hash_file, partition
-from pip._internal.utils.unpacking import (
+from fetchcode.vcs.pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
+from fetchcode.vcs.pip._internal.models.scheme import SCHEME_KEYS, Scheme
+from fetchcode.vcs.pip._internal.utils.filesystem import adjacent_tmp_file, replace
+from fetchcode.vcs.pip._internal.utils.misc import StreamWrapper, ensure_dir, hash_file, partition
+from fetchcode.vcs.pip._internal.utils.unpacking import (
     current_umask,
     is_within_directory,
     set_extracted_file_to_default_mode_plus_executable,
     zip_item_is_executable,
 )
-from pip._internal.utils.wheel import parse_wheel
+from fetchcode.vcs.pip._internal.utils.wheel import parse_wheel
 
 if TYPE_CHECKING:
 

--- a/src/fetchcode/vcs/pip/_internal/operations/prepare.py
+++ b/src/fetchcode/vcs/pip/_internal/operations/prepare.py
@@ -11,11 +11,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.distributions import make_distribution_for_install_requirement
-from pip._internal.distributions.installed import InstalledDistribution
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.distributions import make_distribution_for_install_requirement
+from fetchcode.vcs.pip._internal.distributions.installed import InstalledDistribution
+from fetchcode.vcs.pip._internal.exceptions import (
     DirectoryUrlHashUnsupported,
     HashMismatch,
     HashUnpinned,
@@ -24,35 +24,35 @@ from pip._internal.exceptions import (
     NetworkConnectionError,
     VcsHashUnsupported,
 )
-from pip._internal.index.package_finder import PackageFinder
-from pip._internal.metadata import BaseDistribution, get_metadata_distribution
-from pip._internal.models.direct_url import ArchiveInfo
-from pip._internal.models.link import Link
-from pip._internal.models.wheel import Wheel
-from pip._internal.network.download import BatchDownloader, Downloader
-from pip._internal.network.lazy_wheel import (
+from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution, get_metadata_distribution
+from fetchcode.vcs.pip._internal.models.direct_url import ArchiveInfo
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.models.wheel import Wheel
+from fetchcode.vcs.pip._internal.network.download import BatchDownloader, Downloader
+from fetchcode.vcs.pip._internal.network.lazy_wheel import (
     HTTPRangeRequestUnsupported,
     dist_from_wheel_url,
 )
-from pip._internal.network.session import PipSession
-from pip._internal.operations.build.build_tracker import BuildTracker
-from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils._log import getLogger
-from pip._internal.utils.direct_url_helpers import (
+from fetchcode.vcs.pip._internal.network.session import PipSession
+from fetchcode.vcs.pip._internal.operations.build.build_tracker import BuildTracker
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.utils._log import getLogger
+from fetchcode.vcs.pip._internal.utils.direct_url_helpers import (
     direct_url_for_editable,
     direct_url_from_link,
 )
-from pip._internal.utils.hashes import Hashes, MissingHashes
-from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import (
+from fetchcode.vcs.pip._internal.utils.hashes import Hashes, MissingHashes
+from fetchcode.vcs.pip._internal.utils.logging import indent_log
+from fetchcode.vcs.pip._internal.utils.misc import (
     display_path,
     hash_file,
     hide_url,
     redact_auth_from_requirement,
 )
-from pip._internal.utils.temp_dir import TempDirectory
-from pip._internal.utils.unpacking import unpack_file
-from pip._internal.vcs import vcs
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory
+from fetchcode.vcs.pip._internal.utils.unpacking import unpack_file
+from fetchcode.vcs.pip._internal.vcs import vcs
 
 logger = getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/pyproject.py
+++ b/src/fetchcode/vcs/pip/_internal/pyproject.py
@@ -7,16 +7,16 @@ from typing import Any, List, Optional
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    from pip._vendor import tomli as tomllib
+    from fetchcode.vcs.pip._vendor import tomli as tomllib
 
-from pip._vendor.packaging.requirements import InvalidRequirement
+from fetchcode.vcs.pip._vendor.packaging.requirements import InvalidRequirement
 
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.exceptions import (
     InstallationError,
     InvalidPyProjectBuildRequires,
     MissingPyProjectBuildRequires,
 )
-from pip._internal.utils.packaging import get_requirement
+from fetchcode.vcs.pip._internal.utils.packaging import get_requirement
 
 
 def _is_list_of_str(obj: Any) -> bool:

--- a/src/fetchcode/vcs/pip/_internal/req/__init__.py
+++ b/src/fetchcode/vcs/pip/_internal/req/__init__.py
@@ -3,7 +3,7 @@ import logging
 from dataclasses import dataclass
 from typing import Generator, List, Optional, Sequence, Tuple
 
-from pip._internal.utils.logging import indent_log
+from fetchcode.vcs.pip._internal.utils.logging import indent_log
 
 from .req_file import parse_requirements
 from .req_install import InstallRequirement

--- a/src/fetchcode/vcs/pip/_internal/req/constructors.py
+++ b/src/fetchcode/vcs/pip/_internal/req/constructors.py
@@ -15,21 +15,21 @@ import re
 from dataclasses import dataclass
 from typing import Collection, Dict, List, Optional, Set, Tuple, Union
 
-from pip._vendor.packaging.markers import Marker
-from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
-from pip._vendor.packaging.specifiers import Specifier
+from fetchcode.vcs.pip._vendor.packaging.markers import Marker
+from fetchcode.vcs.pip._vendor.packaging.requirements import InvalidRequirement, Requirement
+from fetchcode.vcs.pip._vendor.packaging.specifiers import Specifier
 
-from pip._internal.exceptions import InstallationError
-from pip._internal.models.index import PyPI, TestPyPI
-from pip._internal.models.link import Link
-from pip._internal.models.wheel import Wheel
-from pip._internal.req.req_file import ParsedRequirement
-from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.filetypes import is_archive_file
-from pip._internal.utils.misc import is_installable_dir
-from pip._internal.utils.packaging import get_requirement
-from pip._internal.utils.urls import path_to_url
-from pip._internal.vcs import is_url, vcs
+from fetchcode.vcs.pip._internal.exceptions import InstallationError
+from fetchcode.vcs.pip._internal.models.index import PyPI, TestPyPI
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.models.wheel import Wheel
+from fetchcode.vcs.pip._internal.req.req_file import ParsedRequirement
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.utils.filetypes import is_archive_file
+from fetchcode.vcs.pip._internal.utils.misc import is_installable_dir
+from fetchcode.vcs.pip._internal.utils.packaging import get_requirement
+from fetchcode.vcs.pip._internal.utils.urls import path_to_url
+from fetchcode.vcs.pip._internal.vcs import is_url, vcs
 
 __all__ = [
     "install_req_from_editable",

--- a/src/fetchcode/vcs/pip/_internal/req/req_file.py
+++ b/src/fetchcode/vcs/pip/_internal/req/req_file.py
@@ -22,14 +22,14 @@ from typing import (
     Tuple,
 )
 
-from pip._internal.cli import cmdoptions
-from pip._internal.exceptions import InstallationError, RequirementsFileParseError
-from pip._internal.models.search_scope import SearchScope
-from pip._internal.utils.encoding import auto_decode
+from fetchcode.vcs.pip._internal.cli import cmdoptions
+from fetchcode.vcs.pip._internal.exceptions import InstallationError, RequirementsFileParseError
+from fetchcode.vcs.pip._internal.models.search_scope import SearchScope
+from fetchcode.vcs.pip._internal.utils.encoding import auto_decode
 
 if TYPE_CHECKING:
-    from pip._internal.index.package_finder import PackageFinder
-    from pip._internal.network.session import PipSession
+    from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
+    from fetchcode.vcs.pip._internal.network.session import PipSession
 
 __all__ = ["parse_requirements"]
 
@@ -536,7 +536,7 @@ def get_file_content(url: str, session: "PipSession") -> Tuple[str, str]:
     # Pip has special support for file:// URLs (LocalFSAdapter).
     if scheme in ["http", "https", "file"]:
         # Delay importing heavy network modules until absolutely necessary.
-        from pip._internal.network.utils import raise_for_status
+        from fetchcode.vcs.pip._internal.network.utils import raise_for_status
 
         resp = session.get(url)
         raise_for_status(resp)

--- a/src/fetchcode/vcs/pip/_internal/req/req_install.py
+++ b/src/fetchcode/vcs/pip/_internal/req/req_install.py
@@ -9,40 +9,40 @@ from optparse import Values
 from pathlib import Path
 from typing import Any, Collection, Dict, Iterable, List, Optional, Sequence, Union
 
-from pip._vendor.packaging.markers import Marker
-from pip._vendor.packaging.requirements import Requirement
-from pip._vendor.packaging.specifiers import SpecifierSet
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import Version
-from pip._vendor.packaging.version import parse as parse_version
-from pip._vendor.pyproject_hooks import BuildBackendHookCaller
+from fetchcode.vcs.pip._vendor.packaging.markers import Marker
+from fetchcode.vcs.pip._vendor.packaging.requirements import Requirement
+from fetchcode.vcs.pip._vendor.packaging.specifiers import SpecifierSet
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.version import parse as parse_version
+from fetchcode.vcs.pip._vendor.pyproject_hooks import BuildBackendHookCaller
 
-from pip._internal.build_env import BuildEnvironment, NoOpBuildEnvironment
-from pip._internal.exceptions import InstallationError, PreviousBuildDirError
-from pip._internal.locations import get_scheme
-from pip._internal.metadata import (
+from fetchcode.vcs.pip._internal.build_env import BuildEnvironment, NoOpBuildEnvironment
+from fetchcode.vcs.pip._internal.exceptions import InstallationError, PreviousBuildDirError
+from fetchcode.vcs.pip._internal.locations import get_scheme
+from fetchcode.vcs.pip._internal.metadata import (
     BaseDistribution,
     get_default_environment,
     get_directory_distribution,
     get_wheel_distribution,
 )
-from pip._internal.metadata.base import FilesystemWheel
-from pip._internal.models.direct_url import DirectUrl
-from pip._internal.models.link import Link
-from pip._internal.operations.build.metadata import generate_metadata
-from pip._internal.operations.build.metadata_editable import generate_editable_metadata
-from pip._internal.operations.build.metadata_legacy import (
+from fetchcode.vcs.pip._internal.metadata.base import FilesystemWheel
+from fetchcode.vcs.pip._internal.models.direct_url import DirectUrl
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.operations.build.metadata import generate_metadata
+from fetchcode.vcs.pip._internal.operations.build.metadata_editable import generate_editable_metadata
+from fetchcode.vcs.pip._internal.operations.build.metadata_legacy import (
     generate_metadata as generate_metadata_legacy,
 )
-from pip._internal.operations.install.editable_legacy import (
+from fetchcode.vcs.pip._internal.operations.install.editable_legacy import (
     install_editable as install_editable_legacy,
 )
-from pip._internal.operations.install.wheel import install_wheel
-from pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
-from pip._internal.req.req_uninstall import UninstallPathSet
-from pip._internal.utils.deprecation import deprecated
-from pip._internal.utils.hashes import Hashes
-from pip._internal.utils.misc import (
+from fetchcode.vcs.pip._internal.operations.install.wheel import install_wheel
+from fetchcode.vcs.pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
+from fetchcode.vcs.pip._internal.req.req_uninstall import UninstallPathSet
+from fetchcode.vcs.pip._internal.utils.deprecation import deprecated
+from fetchcode.vcs.pip._internal.utils.hashes import Hashes
+from fetchcode.vcs.pip._internal.utils.misc import (
     ConfiguredBuildBackendHookCaller,
     ask_path_exists,
     backup_dir,
@@ -52,12 +52,12 @@ from pip._internal.utils.misc import (
     redact_auth_from_requirement,
     redact_auth_from_url,
 )
-from pip._internal.utils.packaging import get_requirement
-from pip._internal.utils.subprocess import runner_with_spinner_message
-from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
-from pip._internal.utils.unpacking import unpack_file
-from pip._internal.utils.virtualenv import running_under_virtualenv
-from pip._internal.vcs import vcs
+from fetchcode.vcs.pip._internal.utils.packaging import get_requirement
+from fetchcode.vcs.pip._internal.utils.subprocess import runner_with_spinner_message
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
+from fetchcode.vcs.pip._internal.utils.unpacking import unpack_file
+from fetchcode.vcs.pip._internal.utils.virtualenv import running_under_virtualenv
+from fetchcode.vcs.pip._internal.vcs import vcs
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/req/req_set.py
+++ b/src/fetchcode/vcs/pip/_internal/req/req_set.py
@@ -2,9 +2,9 @@ import logging
 from collections import OrderedDict
 from typing import Dict, List
 
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/req/req_uninstall.py
+++ b/src/fetchcode/vcs/pip/_internal/req/req_uninstall.py
@@ -5,15 +5,15 @@ import sysconfig
 from importlib.util import cache_from_source
 from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, Tuple
 
-from pip._internal.exceptions import LegacyDistutilsInstall, UninstallMissingRecord
-from pip._internal.locations import get_bin_prefix, get_bin_user
-from pip._internal.metadata import BaseDistribution
-from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.egg_link import egg_link_path_from_location
-from pip._internal.utils.logging import getLogger, indent_log
-from pip._internal.utils.misc import ask, normalize_path, renames, rmtree
-from pip._internal.utils.temp_dir import AdjacentTempDirectory, TempDirectory
-from pip._internal.utils.virtualenv import running_under_virtualenv
+from fetchcode.vcs.pip._internal.exceptions import LegacyDistutilsInstall, UninstallMissingRecord
+from fetchcode.vcs.pip._internal.locations import get_bin_prefix, get_bin_user
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution
+from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
+from fetchcode.vcs.pip._internal.utils.egg_link import egg_link_path_from_location
+from fetchcode.vcs.pip._internal.utils.logging import getLogger, indent_log
+from fetchcode.vcs.pip._internal.utils.misc import ask, normalize_path, renames, rmtree
+from fetchcode.vcs.pip._internal.utils.temp_dir import AdjacentTempDirectory, TempDirectory
+from fetchcode.vcs.pip._internal.utils.virtualenv import running_under_virtualenv
 
 logger = getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/resolution/base.py
+++ b/src/fetchcode/vcs/pip/_internal/resolution/base.py
@@ -1,7 +1,7 @@
 from typing import Callable, List, Optional
 
-from pip._internal.req.req_install import InstallRequirement
-from pip._internal.req.req_set import RequirementSet
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.req.req_set import RequirementSet
 
 InstallRequirementProvider = Callable[
     [str, Optional[InstallRequirement]], InstallRequirement

--- a/src/fetchcode/vcs/pip/_internal/resolution/legacy/resolver.py
+++ b/src/fetchcode/vcs/pip/_internal/resolution/legacy/resolver.py
@@ -16,11 +16,11 @@ from collections import defaultdict
 from itertools import chain
 from typing import DefaultDict, Iterable, List, Optional, Set, Tuple
 
-from pip._vendor.packaging import specifiers
-from pip._vendor.packaging.requirements import Requirement
+from fetchcode.vcs.pip._vendor.packaging import specifiers
+from fetchcode.vcs.pip._vendor.packaging.requirements import Requirement
 
-from pip._internal.cache import WheelCache
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.cache import WheelCache
+from fetchcode.vcs.pip._internal.exceptions import (
     BestVersionAlreadyInstalled,
     DistributionNotFound,
     HashError,
@@ -29,23 +29,23 @@ from pip._internal.exceptions import (
     NoneMetadataError,
     UnsupportedPythonVersion,
 )
-from pip._internal.index.package_finder import PackageFinder
-from pip._internal.metadata import BaseDistribution
-from pip._internal.models.link import Link
-from pip._internal.models.wheel import Wheel
-from pip._internal.operations.prepare import RequirementPreparer
-from pip._internal.req.req_install import (
+from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.models.wheel import Wheel
+from fetchcode.vcs.pip._internal.operations.prepare import RequirementPreparer
+from fetchcode.vcs.pip._internal.req.req_install import (
     InstallRequirement,
     check_invalid_constraint_type,
 )
-from pip._internal.req.req_set import RequirementSet
-from pip._internal.resolution.base import BaseResolver, InstallRequirementProvider
-from pip._internal.utils import compatibility_tags
-from pip._internal.utils.compatibility_tags import get_supported
-from pip._internal.utils.direct_url_helpers import direct_url_from_link
-from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import normalize_version_info
-from pip._internal.utils.packaging import check_requires_python
+from fetchcode.vcs.pip._internal.req.req_set import RequirementSet
+from fetchcode.vcs.pip._internal.resolution.base import BaseResolver, InstallRequirementProvider
+from fetchcode.vcs.pip._internal.utils import compatibility_tags
+from fetchcode.vcs.pip._internal.utils.compatibility_tags import get_supported
+from fetchcode.vcs.pip._internal.utils.direct_url_helpers import direct_url_from_link
+from fetchcode.vcs.pip._internal.utils.logging import indent_log
+from fetchcode.vcs.pip._internal.utils.misc import normalize_version_info
+from fetchcode.vcs.pip._internal.utils.packaging import check_requires_python
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/base.py
+++ b/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/base.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
 from typing import FrozenSet, Iterable, Optional, Tuple
 
-from pip._vendor.packaging.specifiers import SpecifierSet
-from pip._vendor.packaging.utils import NormalizedName
-from pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.specifiers import SpecifierSet
+from fetchcode.vcs.pip._vendor.packaging.utils import NormalizedName
+from fetchcode.vcs.pip._vendor.packaging.version import Version
 
-from pip._internal.models.link import Link, links_equivalent
-from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.hashes import Hashes
+from fetchcode.vcs.pip._internal.models.link import Link, links_equivalent
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.utils.hashes import Hashes
 
 CandidateLookup = Tuple[Optional["Candidate"], Optional[InstallRequirement]]
 

--- a/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/candidates.py
@@ -2,26 +2,26 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, Optional, Tuple, Union, cast
 
-from pip._vendor.packaging.requirements import InvalidRequirement
-from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
-from pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.requirements import InvalidRequirement
+from fetchcode.vcs.pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.version import Version
 
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.exceptions import (
     HashError,
     InstallationSubprocessError,
     MetadataInconsistent,
     MetadataInvalid,
 )
-from pip._internal.metadata import BaseDistribution
-from pip._internal.models.link import Link, links_equivalent
-from pip._internal.models.wheel import Wheel
-from pip._internal.req.constructors import (
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution
+from fetchcode.vcs.pip._internal.models.link import Link, links_equivalent
+from fetchcode.vcs.pip._internal.models.wheel import Wheel
+from fetchcode.vcs.pip._internal.req.constructors import (
     install_req_from_editable,
     install_req_from_line,
 )
-from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.direct_url_helpers import direct_url_from_link
-from pip._internal.utils.misc import normalize_version_info
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.utils.direct_url_helpers import direct_url_from_link
+from fetchcode.vcs.pip._internal.utils.misc import normalize_version_info
 
 from .base import Candidate, Requirement, format_name
 

--- a/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/factory.py
@@ -20,14 +20,14 @@ from typing import (
     cast,
 )
 
-from pip._vendor.packaging.requirements import InvalidRequirement
-from pip._vendor.packaging.specifiers import SpecifierSet
-from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
-from pip._vendor.packaging.version import Version
-from pip._vendor.resolvelib import ResolutionImpossible
+from fetchcode.vcs.pip._vendor.packaging.requirements import InvalidRequirement
+from fetchcode.vcs.pip._vendor.packaging.specifiers import SpecifierSet
+from fetchcode.vcs.pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.resolvelib import ResolutionImpossible
 
-from pip._internal.cache import CacheEntry, WheelCache
-from pip._internal.exceptions import (
+from fetchcode.vcs.pip._internal.cache import CacheEntry, WheelCache
+from fetchcode.vcs.pip._internal.exceptions import (
     DistributionNotFound,
     InstallationError,
     MetadataInconsistent,
@@ -35,24 +35,24 @@ from pip._internal.exceptions import (
     UnsupportedPythonVersion,
     UnsupportedWheel,
 )
-from pip._internal.index.package_finder import PackageFinder
-from pip._internal.metadata import BaseDistribution, get_default_environment
-from pip._internal.models.link import Link
-from pip._internal.models.wheel import Wheel
-from pip._internal.operations.prepare import RequirementPreparer
-from pip._internal.req.constructors import (
+from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
+from fetchcode.vcs.pip._internal.metadata import BaseDistribution, get_default_environment
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.models.wheel import Wheel
+from fetchcode.vcs.pip._internal.operations.prepare import RequirementPreparer
+from fetchcode.vcs.pip._internal.req.constructors import (
     install_req_drop_extras,
     install_req_from_link_and_ireq,
 )
-from pip._internal.req.req_install import (
+from fetchcode.vcs.pip._internal.req.req_install import (
     InstallRequirement,
     check_invalid_constraint_type,
 )
-from pip._internal.resolution.base import InstallRequirementProvider
-from pip._internal.utils.compatibility_tags import get_supported
-from pip._internal.utils.hashes import Hashes
-from pip._internal.utils.packaging import get_requirement
-from pip._internal.utils.virtualenv import running_under_virtualenv
+from fetchcode.vcs.pip._internal.resolution.base import InstallRequirementProvider
+from fetchcode.vcs.pip._internal.utils.compatibility_tags import get_supported
+from fetchcode.vcs.pip._internal.utils.hashes import Hashes
+from fetchcode.vcs.pip._internal.utils.packaging import get_requirement
+from fetchcode.vcs.pip._internal.utils.virtualenv import running_under_virtualenv
 
 from .base import Candidate, Constraint, Requirement
 from .candidates import (

--- a/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/found_candidates.py
+++ b/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/found_candidates.py
@@ -13,9 +13,9 @@ import logging
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Set, Tuple
 
-from pip._vendor.packaging.version import _BaseVersion
+from fetchcode.vcs.pip._vendor.packaging.version import _BaseVersion
 
-from pip._internal.exceptions import MetadataInvalid
+from fetchcode.vcs.pip._internal.exceptions import MetadataInvalid
 
 from .base import Candidate
 

--- a/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/provider.py
@@ -12,15 +12,15 @@ from typing import (
     Union,
 )
 
-from pip._vendor.resolvelib.providers import AbstractProvider
+from fetchcode.vcs.pip._vendor.resolvelib.providers import AbstractProvider
 
 from .base import Candidate, Constraint, Requirement
 from .candidates import REQUIRES_PYTHON_IDENTIFIER
 from .factory import Factory
 
 if TYPE_CHECKING:
-    from pip._vendor.resolvelib.providers import Preference
-    from pip._vendor.resolvelib.resolvers import RequirementInformation
+    from fetchcode.vcs.pip._vendor.resolvelib.providers import Preference
+    from fetchcode.vcs.pip._vendor.resolvelib.resolvers import RequirementInformation
 
     PreferenceInformation = RequirementInformation[Requirement, Candidate]
 

--- a/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/reporter.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from logging import getLogger
 from typing import Any, DefaultDict
 
-from pip._vendor.resolvelib.reporters import BaseReporter
+from fetchcode.vcs.pip._vendor.resolvelib.reporters import BaseReporter
 
 from .base import Candidate, Requirement
 

--- a/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/requirements.py
@@ -1,10 +1,10 @@
 from typing import Any, Optional
 
-from pip._vendor.packaging.specifiers import SpecifierSet
-from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.specifiers import SpecifierSet
+from fetchcode.vcs.pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 
-from pip._internal.req.constructors import install_req_drop_extras
-from pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.req.constructors import install_req_drop_extras
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
 
 from .base import Candidate, CandidateLookup, Requirement, format_name
 

--- a/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/fetchcode/vcs/pip/_internal/resolution/resolvelib/resolver.py
@@ -4,30 +4,30 @@ import logging
 import os
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, cast
 
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible
-from pip._vendor.resolvelib import Resolver as RLResolver
-from pip._vendor.resolvelib.structs import DirectedGraph
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.resolvelib import BaseReporter, ResolutionImpossible
+from fetchcode.vcs.pip._vendor.resolvelib import Resolver as RLResolver
+from fetchcode.vcs.pip._vendor.resolvelib.structs import DirectedGraph
 
-from pip._internal.cache import WheelCache
-from pip._internal.index.package_finder import PackageFinder
-from pip._internal.operations.prepare import RequirementPreparer
-from pip._internal.req.constructors import install_req_extend_extras
-from pip._internal.req.req_install import InstallRequirement
-from pip._internal.req.req_set import RequirementSet
-from pip._internal.resolution.base import BaseResolver, InstallRequirementProvider
-from pip._internal.resolution.resolvelib.provider import PipProvider
-from pip._internal.resolution.resolvelib.reporter import (
+from fetchcode.vcs.pip._internal.cache import WheelCache
+from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
+from fetchcode.vcs.pip._internal.operations.prepare import RequirementPreparer
+from fetchcode.vcs.pip._internal.req.constructors import install_req_extend_extras
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.req.req_set import RequirementSet
+from fetchcode.vcs.pip._internal.resolution.base import BaseResolver, InstallRequirementProvider
+from fetchcode.vcs.pip._internal.resolution.resolvelib.provider import PipProvider
+from fetchcode.vcs.pip._internal.resolution.resolvelib.reporter import (
     PipDebuggingReporter,
     PipReporter,
 )
-from pip._internal.utils.packaging import get_requirement
+from fetchcode.vcs.pip._internal.utils.packaging import get_requirement
 
 from .base import Candidate, Requirement
 from .factory import Factory
 
 if TYPE_CHECKING:
-    from pip._vendor.resolvelib.resolvers import Result as RLResult
+    from fetchcode.vcs.pip._vendor.resolvelib.resolvers import Result as RLResult
 
     Result = RLResult[Requirement, Candidate, str]
 

--- a/src/fetchcode/vcs/pip/_internal/self_outdated_check.py
+++ b/src/fetchcode/vcs/pip/_internal/self_outdated_check.py
@@ -9,24 +9,24 @@ import sys
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 
-from pip._vendor.packaging.version import Version
-from pip._vendor.packaging.version import parse as parse_version
-from pip._vendor.rich.console import Group
-from pip._vendor.rich.markup import escape
-from pip._vendor.rich.text import Text
+from fetchcode.vcs.pip._vendor.packaging.version import Version
+from fetchcode.vcs.pip._vendor.packaging.version import parse as parse_version
+from fetchcode.vcs.pip._vendor.rich.console import Group
+from fetchcode.vcs.pip._vendor.rich.markup import escape
+from fetchcode.vcs.pip._vendor.rich.text import Text
 
-from pip._internal.index.collector import LinkCollector
-from pip._internal.index.package_finder import PackageFinder
-from pip._internal.metadata import get_default_environment
-from pip._internal.models.selection_prefs import SelectionPreferences
-from pip._internal.network.session import PipSession
-from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.entrypoints import (
+from fetchcode.vcs.pip._internal.index.collector import LinkCollector
+from fetchcode.vcs.pip._internal.index.package_finder import PackageFinder
+from fetchcode.vcs.pip._internal.metadata import get_default_environment
+from fetchcode.vcs.pip._internal.models.selection_prefs import SelectionPreferences
+from fetchcode.vcs.pip._internal.network.session import PipSession
+from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
+from fetchcode.vcs.pip._internal.utils.entrypoints import (
     get_best_invocation_for_this_pip,
     get_best_invocation_for_this_python,
 )
-from pip._internal.utils.filesystem import adjacent_tmp_file, check_path_owner, replace
-from pip._internal.utils.misc import ensure_dir
+from fetchcode.vcs.pip._internal.utils.filesystem import adjacent_tmp_file, check_path_owner, replace
+from fetchcode.vcs.pip._internal.utils.misc import ensure_dir
 
 _WEEK = datetime.timedelta(days=7)
 

--- a/src/fetchcode/vcs/pip/_internal/utils/appdirs.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/appdirs.py
@@ -10,7 +10,7 @@ import os
 import sys
 from typing import List
 
-from pip._vendor import platformdirs as _appdirs
+from fetchcode.vcs.pip._vendor import platformdirs as _appdirs
 
 
 def user_cache_dir(appname: str) -> str:

--- a/src/fetchcode/vcs/pip/_internal/utils/compat.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/compat.py
@@ -21,7 +21,7 @@ def has_tls() -> bool:
     except ImportError:
         pass
 
-    from pip._vendor.urllib3.util import IS_PYOPENSSL
+    from fetchcode.vcs.pip._vendor.urllib3.util import IS_PYOPENSSL
 
     return IS_PYOPENSSL
 

--- a/src/fetchcode/vcs/pip/_internal/utils/compatibility_tags.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/compatibility_tags.py
@@ -4,7 +4,7 @@
 import re
 from typing import List, Optional, Tuple
 
-from pip._vendor.packaging.tags import (
+from fetchcode.vcs.pip._vendor.packaging.tags import (
     PythonVersion,
     Tag,
     compatible_tags,

--- a/src/fetchcode/vcs/pip/_internal/utils/deprecation.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/deprecation.py
@@ -6,7 +6,7 @@ import logging
 import warnings
 from typing import Any, Optional, TextIO, Type, Union
 
-from pip._vendor.packaging.version import parse
+from fetchcode.vcs.pip._vendor.packaging.version import parse
 
 from pip import __version__ as current_version  # NOTE: tests patch this name.
 

--- a/src/fetchcode/vcs/pip/_internal/utils/direct_url_helpers.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/direct_url_helpers.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
-from pip._internal.models.direct_url import ArchiveInfo, DirectUrl, DirInfo, VcsInfo
-from pip._internal.models.link import Link
-from pip._internal.utils.urls import path_to_url
-from pip._internal.vcs import vcs
+from fetchcode.vcs.pip._internal.models.direct_url import ArchiveInfo, DirectUrl, DirInfo, VcsInfo
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.utils.urls import path_to_url
+from fetchcode.vcs.pip._internal.vcs import vcs
 
 
 def direct_url_as_pep440_direct_reference(direct_url: DirectUrl, name: str) -> str:

--- a/src/fetchcode/vcs/pip/_internal/utils/egg_link.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/egg_link.py
@@ -3,8 +3,8 @@ import re
 import sys
 from typing import List, Optional
 
-from pip._internal.locations import site_packages, user_site
-from pip._internal.utils.virtualenv import (
+from fetchcode.vcs.pip._internal.locations import site_packages, user_site
+from fetchcode.vcs.pip._internal.utils.virtualenv import (
     running_under_virtualenv,
     virtualenv_no_global,
 )

--- a/src/fetchcode/vcs/pip/_internal/utils/entrypoints.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/entrypoints.py
@@ -4,8 +4,8 @@ import shutil
 import sys
 from typing import List, Optional
 
-from pip._internal.cli.main import main
-from pip._internal.utils.compat import WINDOWS
+from fetchcode.vcs.pip._internal.cli.main import main
+from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
 
 _EXECUTABLE_NAMES = [
     "pip",

--- a/src/fetchcode/vcs/pip/_internal/utils/filesystem.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/filesystem.py
@@ -7,9 +7,9 @@ from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 from typing import Any, BinaryIO, Generator, List, Union, cast
 
-from pip._internal.utils.compat import get_path_uid
-from pip._internal.utils.misc import format_size
-from pip._internal.utils.retry import retry
+from fetchcode.vcs.pip._internal.utils.compat import get_path_uid
+from fetchcode.vcs.pip._internal.utils.misc import format_size
+from fetchcode.vcs.pip._internal.utils.retry import retry
 
 
 def check_path_owner(path: str) -> bool:

--- a/src/fetchcode/vcs/pip/_internal/utils/filetypes.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/filetypes.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple
 
-from pip._internal.utils.misc import splitext
+from fetchcode.vcs.pip._internal.utils.misc import splitext
 
 WHEEL_EXTENSION = ".whl"
 BZ2_EXTENSIONS: Tuple[str, ...] = (".tar.bz2", ".tbz")

--- a/src/fetchcode/vcs/pip/_internal/utils/hashes.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/hashes.py
@@ -1,8 +1,8 @@
 import hashlib
 from typing import TYPE_CHECKING, BinaryIO, Dict, Iterable, List, NoReturn, Optional
 
-from pip._internal.exceptions import HashMismatch, HashMissing, InstallationError
-from pip._internal.utils.misc import read_chunks
+from fetchcode.vcs.pip._internal.exceptions import HashMismatch, HashMissing, InstallationError
+from fetchcode.vcs.pip._internal.utils.misc import read_chunks
 
 if TYPE_CHECKING:
     from hashlib import _Hash

--- a/src/fetchcode/vcs/pip/_internal/utils/logging.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/logging.py
@@ -10,7 +10,7 @@ from io import TextIOWrapper
 from logging import Filter
 from typing import Any, ClassVar, Generator, List, Optional, TextIO, Type
 
-from pip._vendor.rich.console import (
+from fetchcode.vcs.pip._vendor.rich.console import (
     Console,
     ConsoleOptions,
     ConsoleRenderable,
@@ -18,15 +18,15 @@ from pip._vendor.rich.console import (
     RenderResult,
     RichCast,
 )
-from pip._vendor.rich.highlighter import NullHighlighter
-from pip._vendor.rich.logging import RichHandler
-from pip._vendor.rich.segment import Segment
-from pip._vendor.rich.style import Style
+from fetchcode.vcs.pip._vendor.rich.highlighter import NullHighlighter
+from fetchcode.vcs.pip._vendor.rich.logging import RichHandler
+from fetchcode.vcs.pip._vendor.rich.segment import Segment
+from fetchcode.vcs.pip._vendor.rich.style import Style
 
-from pip._internal.utils._log import VERBOSE, getLogger
-from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
-from pip._internal.utils.misc import ensure_dir
+from fetchcode.vcs.pip._internal.utils._log import VERBOSE, getLogger
+from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
+from fetchcode.vcs.pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
+from fetchcode.vcs.pip._internal.utils.misc import ensure_dir
 
 _log_state = threading.local()
 subprocess_logger = getLogger("pip.subprocessor")

--- a/src/fetchcode/vcs/pip/_internal/utils/misc.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/misc.py
@@ -33,15 +33,15 @@ from typing import (
     cast,
 )
 
-from pip._vendor.packaging.requirements import Requirement
-from pip._vendor.pyproject_hooks import BuildBackendHookCaller
+from fetchcode.vcs.pip._vendor.packaging.requirements import Requirement
+from fetchcode.vcs.pip._vendor.pyproject_hooks import BuildBackendHookCaller
 
 from pip import __version__
-from pip._internal.exceptions import CommandError, ExternallyManagedEnvironment
-from pip._internal.locations import get_major_minor_version
-from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.retry import retry
-from pip._internal.utils.virtualenv import running_under_virtualenv
+from fetchcode.vcs.pip._internal.exceptions import CommandError, ExternallyManagedEnvironment
+from fetchcode.vcs.pip._internal.locations import get_major_minor_version
+from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
+from fetchcode.vcs.pip._internal.utils.retry import retry
+from fetchcode.vcs.pip._internal.utils.virtualenv import running_under_virtualenv
 
 __all__ = [
     "rmtree",

--- a/src/fetchcode/vcs/pip/_internal/utils/packaging.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/packaging.py
@@ -3,8 +3,8 @@ import logging
 import re
 from typing import NewType, Optional, Tuple, cast
 
-from pip._vendor.packaging import specifiers, version
-from pip._vendor.packaging.requirements import Requirement
+from fetchcode.vcs.pip._vendor.packaging import specifiers, version
+from fetchcode.vcs.pip._vendor.packaging.requirements import Requirement
 
 NormalizedExtra = NewType("NormalizedExtra", str)
 

--- a/src/fetchcode/vcs/pip/_internal/utils/retry.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/retry.py
@@ -2,7 +2,7 @@ import functools
 from time import perf_counter, sleep
 from typing import Callable, TypeVar
 
-from pip._vendor.typing_extensions import ParamSpec
+from fetchcode.vcs.pip._vendor.typing_extensions import ParamSpec
 
 T = TypeVar("T")
 P = ParamSpec("P")

--- a/src/fetchcode/vcs/pip/_internal/utils/subprocess.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/subprocess.py
@@ -4,12 +4,12 @@ import shlex
 import subprocess
 from typing import Any, Callable, Iterable, List, Literal, Mapping, Optional, Union
 
-from pip._vendor.rich.markup import escape
+from fetchcode.vcs.pip._vendor.rich.markup import escape
 
-from pip._internal.cli.spinners import SpinnerInterface, open_spinner
-from pip._internal.exceptions import InstallationSubprocessError
-from pip._internal.utils.logging import VERBOSE, subprocess_logger
-from pip._internal.utils.misc import HiddenText
+from fetchcode.vcs.pip._internal.cli.spinners import SpinnerInterface, open_spinner
+from fetchcode.vcs.pip._internal.exceptions import InstallationSubprocessError
+from fetchcode.vcs.pip._internal.utils.logging import VERBOSE, subprocess_logger
+from fetchcode.vcs.pip._internal.utils.misc import HiddenText
 
 CommandArgs = List[Union[str, HiddenText]]
 

--- a/src/fetchcode/vcs/pip/_internal/utils/temp_dir.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/temp_dir.py
@@ -17,7 +17,7 @@ from typing import (
     Union,
 )
 
-from pip._internal.utils.misc import enum, rmtree
+from fetchcode.vcs.pip._internal.utils.misc import enum, rmtree
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/utils/unpacking.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/unpacking.py
@@ -11,14 +11,14 @@ import zipfile
 from typing import Iterable, List, Optional
 from zipfile import ZipInfo
 
-from pip._internal.exceptions import InstallationError
-from pip._internal.utils.filetypes import (
+from fetchcode.vcs.pip._internal.exceptions import InstallationError
+from fetchcode.vcs.pip._internal.utils.filetypes import (
     BZ2_EXTENSIONS,
     TAR_EXTENSIONS,
     XZ_EXTENSIONS,
     ZIP_EXTENSIONS,
 )
-from pip._internal.utils.misc import ensure_dir
+from fetchcode.vcs.pip._internal.utils.misc import ensure_dir
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_internal/utils/wheel.py
+++ b/src/fetchcode/vcs/pip/_internal/utils/wheel.py
@@ -7,9 +7,9 @@ from email.parser import Parser
 from typing import Tuple
 from zipfile import BadZipFile, ZipFile
 
-from pip._vendor.packaging.utils import canonicalize_name
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.exceptions import UnsupportedWheel
+from fetchcode.vcs.pip._internal.exceptions import UnsupportedWheel
 
 VERSION_COMPATIBLE = (1, 0)
 

--- a/src/fetchcode/vcs/pip/_internal/vcs/__init__.py
+++ b/src/fetchcode/vcs/pip/_internal/vcs/__init__.py
@@ -6,7 +6,7 @@ import pip._internal.vcs.bazaar
 import pip._internal.vcs.git
 import pip._internal.vcs.mercurial
 import pip._internal.vcs.subversion  # noqa: F401
-from pip._internal.vcs.versioncontrol import (  # noqa: F401
+from fetchcode.vcs.pip._internal.vcs.versioncontrol import (  # noqa: F401
     RemoteNotFoundError,
     RemoteNotValidError,
     is_url,

--- a/src/fetchcode/vcs/pip/_internal/vcs/bazaar.py
+++ b/src/fetchcode/vcs/pip/_internal/vcs/bazaar.py
@@ -1,10 +1,10 @@
 import logging
 from typing import List, Optional, Tuple
 
-from pip._internal.utils.misc import HiddenText, display_path
-from pip._internal.utils.subprocess import make_command
-from pip._internal.utils.urls import path_to_url
-from pip._internal.vcs.versioncontrol import (
+from fetchcode.vcs.pip._internal.utils.misc import HiddenText, display_path
+from fetchcode.vcs.pip._internal.utils.subprocess import make_command
+from fetchcode.vcs.pip._internal.utils.urls import path_to_url
+from fetchcode.vcs.pip._internal.vcs.versioncontrol import (
     AuthInfo,
     RemoteNotFoundError,
     RevOptions,

--- a/src/fetchcode/vcs/pip/_internal/vcs/git.py
+++ b/src/fetchcode/vcs/pip/_internal/vcs/git.py
@@ -7,10 +7,10 @@ import urllib.request
 from dataclasses import replace
 from typing import List, Optional, Tuple
 
-from pip._internal.exceptions import BadCommand, InstallationError
-from pip._internal.utils.misc import HiddenText, display_path, hide_url
-from pip._internal.utils.subprocess import make_command
-from pip._internal.vcs.versioncontrol import (
+from fetchcode.vcs.pip._internal.exceptions import BadCommand, InstallationError
+from fetchcode.vcs.pip._internal.utils.misc import HiddenText, display_path, hide_url
+from fetchcode.vcs.pip._internal.utils.subprocess import make_command
+from fetchcode.vcs.pip._internal.vcs.versioncontrol import (
     AuthInfo,
     RemoteNotFoundError,
     RemoteNotValidError,

--- a/src/fetchcode/vcs/pip/_internal/vcs/mercurial.py
+++ b/src/fetchcode/vcs/pip/_internal/vcs/mercurial.py
@@ -3,11 +3,11 @@ import logging
 import os
 from typing import List, Optional, Tuple
 
-from pip._internal.exceptions import BadCommand, InstallationError
-from pip._internal.utils.misc import HiddenText, display_path
-from pip._internal.utils.subprocess import make_command
-from pip._internal.utils.urls import path_to_url
-from pip._internal.vcs.versioncontrol import (
+from fetchcode.vcs.pip._internal.exceptions import BadCommand, InstallationError
+from fetchcode.vcs.pip._internal.utils.misc import HiddenText, display_path
+from fetchcode.vcs.pip._internal.utils.subprocess import make_command
+from fetchcode.vcs.pip._internal.utils.urls import path_to_url
+from fetchcode.vcs.pip._internal.vcs.versioncontrol import (
     RevOptions,
     VersionControl,
     find_path_to_project_root_from_repo_root,

--- a/src/fetchcode/vcs/pip/_internal/vcs/subversion.py
+++ b/src/fetchcode/vcs/pip/_internal/vcs/subversion.py
@@ -3,15 +3,15 @@ import os
 import re
 from typing import List, Optional, Tuple
 
-from pip._internal.utils.misc import (
+from fetchcode.vcs.pip._internal.utils.misc import (
     HiddenText,
     display_path,
     is_console_interactive,
     is_installable_dir,
     split_auth_from_netloc,
 )
-from pip._internal.utils.subprocess import CommandArgs, make_command
-from pip._internal.vcs.versioncontrol import (
+from fetchcode.vcs.pip._internal.utils.subprocess import CommandArgs, make_command
+from fetchcode.vcs.pip._internal.vcs.versioncontrol import (
     AuthInfo,
     RemoteNotFoundError,
     RevOptions,
@@ -131,7 +131,7 @@ class Subversion(VersionControl):
 
     @classmethod
     def _get_svn_url_rev(cls, location: str) -> Tuple[Optional[str], int]:
-        from pip._internal.exceptions import InstallationError
+        from fetchcode.vcs.pip._internal.exceptions import InstallationError
 
         entries_path = os.path.join(location, cls.dirname, "entries")
         if os.path.exists(entries_path):

--- a/src/fetchcode/vcs/pip/_internal/vcs/versioncontrol.py
+++ b/src/fetchcode/vcs/pip/_internal/vcs/versioncontrol.py
@@ -20,9 +20,9 @@ from typing import (
     Union,
 )
 
-from pip._internal.cli.spinners import SpinnerInterface
-from pip._internal.exceptions import BadCommand, InstallationError
-from pip._internal.utils.misc import (
+from fetchcode.vcs.pip._internal.cli.spinners import SpinnerInterface
+from fetchcode.vcs.pip._internal.exceptions import BadCommand, InstallationError
+from fetchcode.vcs.pip._internal.utils.misc import (
     HiddenText,
     ask_path_exists,
     backup_dir,
@@ -32,7 +32,7 @@ from pip._internal.utils.misc import (
     is_installable_dir,
     rmtree,
 )
-from pip._internal.utils.subprocess import (
+from fetchcode.vcs.pip._internal.utils.subprocess import (
     CommandArgs,
     call_subprocess,
     format_command_args,

--- a/src/fetchcode/vcs/pip/_internal/wheel_builder.py
+++ b/src/fetchcode/vcs/pip/_internal/wheel_builder.py
@@ -7,25 +7,25 @@ import re
 import shutil
 from typing import Iterable, List, Optional, Tuple
 
-from pip._vendor.packaging.utils import canonicalize_name, canonicalize_version
-from pip._vendor.packaging.version import InvalidVersion, Version
+from fetchcode.vcs.pip._vendor.packaging.utils import canonicalize_name, canonicalize_version
+from fetchcode.vcs.pip._vendor.packaging.version import InvalidVersion, Version
 
-from pip._internal.cache import WheelCache
-from pip._internal.exceptions import InvalidWheelFilename, UnsupportedWheel
-from pip._internal.metadata import FilesystemWheel, get_wheel_distribution
-from pip._internal.models.link import Link
-from pip._internal.models.wheel import Wheel
-from pip._internal.operations.build.wheel import build_wheel_pep517
-from pip._internal.operations.build.wheel_editable import build_wheel_editable
-from pip._internal.operations.build.wheel_legacy import build_wheel_legacy
-from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import ensure_dir, hash_file
-from pip._internal.utils.setuptools_build import make_setuptools_clean_args
-from pip._internal.utils.subprocess import call_subprocess
-from pip._internal.utils.temp_dir import TempDirectory
-from pip._internal.utils.urls import path_to_url
-from pip._internal.vcs import vcs
+from fetchcode.vcs.pip._internal.cache import WheelCache
+from fetchcode.vcs.pip._internal.exceptions import InvalidWheelFilename, UnsupportedWheel
+from fetchcode.vcs.pip._internal.metadata import FilesystemWheel, get_wheel_distribution
+from fetchcode.vcs.pip._internal.models.link import Link
+from fetchcode.vcs.pip._internal.models.wheel import Wheel
+from fetchcode.vcs.pip._internal.operations.build.wheel import build_wheel_pep517
+from fetchcode.vcs.pip._internal.operations.build.wheel_editable import build_wheel_editable
+from fetchcode.vcs.pip._internal.operations.build.wheel_legacy import build_wheel_legacy
+from fetchcode.vcs.pip._internal.req.req_install import InstallRequirement
+from fetchcode.vcs.pip._internal.utils.logging import indent_log
+from fetchcode.vcs.pip._internal.utils.misc import ensure_dir, hash_file
+from fetchcode.vcs.pip._internal.utils.setuptools_build import make_setuptools_clean_args
+from fetchcode.vcs.pip._internal.utils.subprocess import call_subprocess
+from fetchcode.vcs.pip._internal.utils.temp_dir import TempDirectory
+from fetchcode.vcs.pip._internal.utils.urls import path_to_url
+from fetchcode.vcs.pip._internal.vcs import vcs
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_vendor/cachecontrol/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/cachecontrol/__init__.py
@@ -10,9 +10,9 @@ __author__ = "Eric Larson"
 __email__ = "eric@ionrock.org"
 __version__ = "0.14.0"
 
-from pip._vendor.cachecontrol.adapter import CacheControlAdapter
-from pip._vendor.cachecontrol.controller import CacheController
-from pip._vendor.cachecontrol.wrapper import CacheControl
+from fetchcode.vcs.pip._vendor.cachecontrol.adapter import CacheControlAdapter
+from fetchcode.vcs.pip._vendor.cachecontrol.controller import CacheController
+from fetchcode.vcs.pip._vendor.cachecontrol.wrapper import CacheControl
 
 __all__ = [
     "__author__",

--- a/src/fetchcode/vcs/pip/_vendor/cachecontrol/_cmd.py
+++ b/src/fetchcode/vcs/pip/_vendor/cachecontrol/_cmd.py
@@ -7,16 +7,16 @@ import logging
 from argparse import ArgumentParser
 from typing import TYPE_CHECKING
 
-from pip._vendor import requests
+from fetchcode.vcs.pip._vendor import requests
 
-from pip._vendor.cachecontrol.adapter import CacheControlAdapter
-from pip._vendor.cachecontrol.cache import DictCache
-from pip._vendor.cachecontrol.controller import logger
+from fetchcode.vcs.pip._vendor.cachecontrol.adapter import CacheControlAdapter
+from fetchcode.vcs.pip._vendor.cachecontrol.cache import DictCache
+from fetchcode.vcs.pip._vendor.cachecontrol.controller import logger
 
 if TYPE_CHECKING:
     from argparse import Namespace
 
-    from pip._vendor.cachecontrol.controller import CacheController
+    from fetchcode.vcs.pip._vendor.cachecontrol.controller import CacheController
 
 
 def setup_logging() -> None:

--- a/src/fetchcode/vcs/pip/_vendor/cachecontrol/adapter.py
+++ b/src/fetchcode/vcs/pip/_vendor/cachecontrol/adapter.py
@@ -8,19 +8,19 @@ import types
 import zlib
 from typing import TYPE_CHECKING, Any, Collection, Mapping
 
-from pip._vendor.requests.adapters import HTTPAdapter
+from fetchcode.vcs.pip._vendor.requests.adapters import HTTPAdapter
 
-from pip._vendor.cachecontrol.cache import DictCache
-from pip._vendor.cachecontrol.controller import PERMANENT_REDIRECT_STATUSES, CacheController
-from pip._vendor.cachecontrol.filewrapper import CallbackFileWrapper
+from fetchcode.vcs.pip._vendor.cachecontrol.cache import DictCache
+from fetchcode.vcs.pip._vendor.cachecontrol.controller import PERMANENT_REDIRECT_STATUSES, CacheController
+from fetchcode.vcs.pip._vendor.cachecontrol.filewrapper import CallbackFileWrapper
 
 if TYPE_CHECKING:
-    from pip._vendor.requests import PreparedRequest, Response
-    from pip._vendor.urllib3 import HTTPResponse
+    from fetchcode.vcs.pip._vendor.requests import PreparedRequest, Response
+    from fetchcode.vcs.pip._vendor.urllib3 import HTTPResponse
 
-    from pip._vendor.cachecontrol.cache import BaseCache
-    from pip._vendor.cachecontrol.heuristics import BaseHeuristic
-    from pip._vendor.cachecontrol.serialize import Serializer
+    from fetchcode.vcs.pip._vendor.cachecontrol.cache import BaseCache
+    from fetchcode.vcs.pip._vendor.cachecontrol.heuristics import BaseHeuristic
+    from fetchcode.vcs.pip._vendor.cachecontrol.serialize import Serializer
 
 
 class CacheControlAdapter(HTTPAdapter):

--- a/src/fetchcode/vcs/pip/_vendor/cachecontrol/caches/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/cachecontrol/caches/__init__.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from pip._vendor.cachecontrol.caches.file_cache import FileCache, SeparateBodyFileCache
-from pip._vendor.cachecontrol.caches.redis_cache import RedisCache
+from fetchcode.vcs.pip._vendor.cachecontrol.caches.file_cache import FileCache, SeparateBodyFileCache
+from fetchcode.vcs.pip._vendor.cachecontrol.caches.redis_cache import RedisCache
 
 __all__ = ["FileCache", "SeparateBodyFileCache", "RedisCache"]

--- a/src/fetchcode/vcs/pip/_vendor/cachecontrol/caches/file_cache.py
+++ b/src/fetchcode/vcs/pip/_vendor/cachecontrol/caches/file_cache.py
@@ -9,8 +9,8 @@ from textwrap import dedent
 from typing import IO, TYPE_CHECKING, Union
 from pathlib import Path
 
-from pip._vendor.cachecontrol.cache import BaseCache, SeparateBodyBaseCache
-from pip._vendor.cachecontrol.controller import CacheController
+from fetchcode.vcs.pip._vendor.cachecontrol.cache import BaseCache, SeparateBodyBaseCache
+from fetchcode.vcs.pip._vendor.cachecontrol.controller import CacheController
 
 if TYPE_CHECKING:
     from datetime import datetime

--- a/src/fetchcode/vcs/pip/_vendor/cachecontrol/caches/redis_cache.py
+++ b/src/fetchcode/vcs/pip/_vendor/cachecontrol/caches/redis_cache.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from pip._vendor.cachecontrol.cache import BaseCache
+from fetchcode.vcs.pip._vendor.cachecontrol.cache import BaseCache
 
 if TYPE_CHECKING:
     from redis import Redis

--- a/src/fetchcode/vcs/pip/_vendor/cachecontrol/controller.py
+++ b/src/fetchcode/vcs/pip/_vendor/cachecontrol/controller.py
@@ -14,18 +14,18 @@ import time
 from email.utils import parsedate_tz
 from typing import TYPE_CHECKING, Collection, Mapping
 
-from pip._vendor.requests.structures import CaseInsensitiveDict
+from fetchcode.vcs.pip._vendor.requests.structures import CaseInsensitiveDict
 
-from pip._vendor.cachecontrol.cache import DictCache, SeparateBodyBaseCache
-from pip._vendor.cachecontrol.serialize import Serializer
+from fetchcode.vcs.pip._vendor.cachecontrol.cache import DictCache, SeparateBodyBaseCache
+from fetchcode.vcs.pip._vendor.cachecontrol.serialize import Serializer
 
 if TYPE_CHECKING:
     from typing import Literal
 
-    from pip._vendor.requests import PreparedRequest
-    from pip._vendor.urllib3 import HTTPResponse
+    from fetchcode.vcs.pip._vendor.requests import PreparedRequest
+    from fetchcode.vcs.pip._vendor.urllib3 import HTTPResponse
 
-    from pip._vendor.cachecontrol.cache import BaseCache
+    from fetchcode.vcs.pip._vendor.cachecontrol.cache import BaseCache
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetchcode/vcs/pip/_vendor/cachecontrol/heuristics.py
+++ b/src/fetchcode/vcs/pip/_vendor/cachecontrol/heuristics.py
@@ -10,7 +10,7 @@ from email.utils import formatdate, parsedate, parsedate_tz
 from typing import TYPE_CHECKING, Any, Mapping
 
 if TYPE_CHECKING:
-    from pip._vendor.urllib3 import HTTPResponse
+    from fetchcode.vcs.pip._vendor.urllib3 import HTTPResponse
 
 TIME_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 

--- a/src/fetchcode/vcs/pip/_vendor/cachecontrol/serialize.py
+++ b/src/fetchcode/vcs/pip/_vendor/cachecontrol/serialize.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 import io
 from typing import IO, TYPE_CHECKING, Any, Mapping, cast
 
-from pip._vendor import msgpack
-from pip._vendor.requests.structures import CaseInsensitiveDict
-from pip._vendor.urllib3 import HTTPResponse
+from fetchcode.vcs.pip._vendor import msgpack
+from fetchcode.vcs.pip._vendor.requests.structures import CaseInsensitiveDict
+from fetchcode.vcs.pip._vendor.urllib3 import HTTPResponse
 
 if TYPE_CHECKING:
-    from pip._vendor.requests import PreparedRequest
+    from fetchcode.vcs.pip._vendor.requests import PreparedRequest
 
 
 class Serializer:

--- a/src/fetchcode/vcs/pip/_vendor/cachecontrol/wrapper.py
+++ b/src/fetchcode/vcs/pip/_vendor/cachecontrol/wrapper.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Collection
 
-from pip._vendor.cachecontrol.adapter import CacheControlAdapter
-from pip._vendor.cachecontrol.cache import DictCache
+from fetchcode.vcs.pip._vendor.cachecontrol.adapter import CacheControlAdapter
+from fetchcode.vcs.pip._vendor.cachecontrol.cache import DictCache
 
 if TYPE_CHECKING:
-    from pip._vendor import requests
+    from fetchcode.vcs.pip._vendor import requests
 
-    from pip._vendor.cachecontrol.cache import BaseCache
-    from pip._vendor.cachecontrol.controller import CacheController
-    from pip._vendor.cachecontrol.heuristics import BaseHeuristic
-    from pip._vendor.cachecontrol.serialize import Serializer
+    from fetchcode.vcs.pip._vendor.cachecontrol.cache import BaseCache
+    from fetchcode.vcs.pip._vendor.cachecontrol.controller import CacheController
+    from fetchcode.vcs.pip._vendor.cachecontrol.heuristics import BaseHeuristic
+    from fetchcode.vcs.pip._vendor.cachecontrol.serialize import Serializer
 
 
 def CacheControl(

--- a/src/fetchcode/vcs/pip/_vendor/certifi/__main__.py
+++ b/src/fetchcode/vcs/pip/_vendor/certifi/__main__.py
@@ -1,6 +1,6 @@
 import argparse
 
-from pip._vendor.certifi import contents, where
+from fetchcode.vcs.pip._vendor.certifi import contents, where
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-c", "--contents", action="store_true")

--- a/src/fetchcode/vcs/pip/_vendor/packaging/specifiers.py
+++ b/src/fetchcode/vcs/pip/_vendor/packaging/specifiers.py
@@ -4,8 +4,8 @@
 """
 .. testsetup::
 
-    from pip._vendor.packaging.specifiers import Specifier, SpecifierSet, InvalidSpecifier
-    from pip._vendor.packaging.version import Version
+    from fetchcode.vcs.pip._vendor.packaging.specifiers import Specifier, SpecifierSet, InvalidSpecifier
+    from fetchcode.vcs.pip._vendor.packaging.version import Version
 """
 
 from __future__ import annotations

--- a/src/fetchcode/vcs/pip/_vendor/packaging/version.py
+++ b/src/fetchcode/vcs/pip/_vendor/packaging/version.py
@@ -4,7 +4,7 @@
 """
 .. testsetup::
 
-    from pip._vendor.packaging.version import parse, Version
+    from fetchcode.vcs.pip._vendor.packaging.version import parse, Version
 """
 
 from __future__ import annotations

--- a/src/fetchcode/vcs/pip/_vendor/pkg_resources/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/pkg_resources/__init__.py
@@ -87,20 +87,20 @@ except ImportError:
     # no write support, probably under GAE
     WRITE_SUPPORT = False
 
-from pip._internal.utils._jaraco_text import (
+from fetchcode.vcs.pip._internal.utils._jaraco_text import (
     yield_lines,
     drop_comment,
     join_continuation,
 )
-from pip._vendor.packaging import markers as _packaging_markers
-from pip._vendor.packaging import requirements as _packaging_requirements
-from pip._vendor.packaging import utils as _packaging_utils
-from pip._vendor.packaging import version as _packaging_version
-from pip._vendor.platformdirs import user_cache_dir as _user_cache_dir
+from fetchcode.vcs.pip._vendor.packaging import markers as _packaging_markers
+from fetchcode.vcs.pip._vendor.packaging import requirements as _packaging_requirements
+from fetchcode.vcs.pip._vendor.packaging import utils as _packaging_utils
+from fetchcode.vcs.pip._vendor.packaging import version as _packaging_version
+from fetchcode.vcs.pip._vendor.platformdirs import user_cache_dir as _user_cache_dir
 
 if TYPE_CHECKING:
     from _typeshed import BytesPath, StrPath, StrOrBytesPath
-    from pip._vendor.typing_extensions import Self
+    from fetchcode.vcs.pip._vendor.typing_extensions import Self
 
 
 # Patch: Remove deprecation warning from vendored pkg_resources.

--- a/src/fetchcode/vcs/pip/_vendor/platformdirs/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/platformdirs/__init__.py
@@ -22,20 +22,20 @@ if TYPE_CHECKING:
 
 def _set_platform_dir_class() -> type[PlatformDirsABC]:
     if sys.platform == "win32":
-        from pip._vendor.platformdirs.windows import Windows as Result  # noqa: PLC0415
+        from fetchcode.vcs.pip._vendor.platformdirs.windows import Windows as Result  # noqa: PLC0415
     elif sys.platform == "darwin":
-        from pip._vendor.platformdirs.macos import MacOS as Result  # noqa: PLC0415
+        from fetchcode.vcs.pip._vendor.platformdirs.macos import MacOS as Result  # noqa: PLC0415
     else:
-        from pip._vendor.platformdirs.unix import Unix as Result  # noqa: PLC0415
+        from fetchcode.vcs.pip._vendor.platformdirs.unix import Unix as Result  # noqa: PLC0415
 
     if os.getenv("ANDROID_DATA") == "/data" and os.getenv("ANDROID_ROOT") == "/system":
         if os.getenv("SHELL") or os.getenv("PREFIX"):
             return Result
 
-        from pip._vendor.platformdirs.android import _android_folder  # noqa: PLC0415
+        from fetchcode.vcs.pip._vendor.platformdirs.android import _android_folder  # noqa: PLC0415
 
         if _android_folder() is not None:
-            from pip._vendor.platformdirs.android import Android  # noqa: PLC0415
+            from fetchcode.vcs.pip._vendor.platformdirs.android import Android  # noqa: PLC0415
 
             return Android  # return to avoid redefinition of a result
 

--- a/src/fetchcode/vcs/pip/_vendor/platformdirs/__main__.py
+++ b/src/fetchcode/vcs/pip/_vendor/platformdirs/__main__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pip._vendor.platformdirs import PlatformDirs, __version__
+from fetchcode.vcs.pip._vendor.platformdirs import PlatformDirs, __version__
 
 PROPS = (
     "user_data_dir",

--- a/src/fetchcode/vcs/pip/_vendor/pygments/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/__init__.py
@@ -42,7 +42,7 @@ def lex(code, lexer):
         return lexer.get_tokens(code)
     except TypeError:
         # Heuristic to catch a common mistake.
-        from pip._vendor.pygments.lexer import RegexLexer
+        from fetchcode.vcs.pip._vendor.pygments.lexer import RegexLexer
         if isinstance(lexer, type) and issubclass(lexer, RegexLexer):
             raise TypeError('lex() argument must be a lexer instance, '
                             'not a class')
@@ -67,7 +67,7 @@ def format(tokens, formatter, outfile=None):  # pylint: disable=redefined-builti
             formatter.format(tokens, outfile)
     except TypeError:
         # Heuristic to catch a common mistake.
-        from pip._vendor.pygments.formatter import Formatter
+        from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
         if isinstance(formatter, type) and issubclass(formatter, Formatter):
             raise TypeError('format() argument must be a formatter instance, '
                             'not a class')

--- a/src/fetchcode/vcs/pip/_vendor/pygments/__main__.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/__main__.py
@@ -9,7 +9,7 @@
 """
 
 import sys
-from pip._vendor.pygments.cmdline import main
+from fetchcode.vcs.pip._vendor.pygments.cmdline import main
 
 try:
     sys.exit(main(sys.argv))

--- a/src/fetchcode/vcs/pip/_vendor/pygments/cmdline.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/cmdline.py
@@ -14,20 +14,20 @@ import shutil
 import argparse
 from textwrap import dedent
 
-from pip._vendor.pygments import __version__, highlight
-from pip._vendor.pygments.util import ClassNotFound, OptionError, docstring_headline, \
+from fetchcode.vcs.pip._vendor.pygments import __version__, highlight
+from fetchcode.vcs.pip._vendor.pygments.util import ClassNotFound, OptionError, docstring_headline, \
     guess_decode, guess_decode_from_terminal, terminal_encoding, \
     UnclosingTextIOWrapper
-from pip._vendor.pygments.lexers import get_all_lexers, get_lexer_by_name, guess_lexer, \
+from fetchcode.vcs.pip._vendor.pygments.lexers import get_all_lexers, get_lexer_by_name, guess_lexer, \
     load_lexer_from_file, get_lexer_for_filename, find_lexer_class_for_filename
-from pip._vendor.pygments.lexers.special import TextLexer
-from pip._vendor.pygments.formatters.latex import LatexEmbeddedLexer, LatexFormatter
-from pip._vendor.pygments.formatters import get_all_formatters, get_formatter_by_name, \
+from fetchcode.vcs.pip._vendor.pygments.lexers.special import TextLexer
+from fetchcode.vcs.pip._vendor.pygments.formatters.latex import LatexEmbeddedLexer, LatexFormatter
+from fetchcode.vcs.pip._vendor.pygments.formatters import get_all_formatters, get_formatter_by_name, \
     load_formatter_from_file, get_formatter_for_filename, find_formatter_class
-from pip._vendor.pygments.formatters.terminal import TerminalFormatter
-from pip._vendor.pygments.formatters.terminal256 import Terminal256Formatter, TerminalTrueColorFormatter
-from pip._vendor.pygments.filters import get_all_filters, find_filter_class
-from pip._vendor.pygments.styles import get_all_styles, get_style_by_name
+from fetchcode.vcs.pip._vendor.pygments.formatters.terminal import TerminalFormatter
+from fetchcode.vcs.pip._vendor.pygments.formatters.terminal256 import Terminal256Formatter, TerminalTrueColorFormatter
+from fetchcode.vcs.pip._vendor.pygments.filters import get_all_filters, find_filter_class
+from fetchcode.vcs.pip._vendor.pygments.styles import get_all_styles, get_style_by_name
 
 
 def _parse_options(o_strs):

--- a/src/fetchcode/vcs/pip/_vendor/pygments/filters/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/filters/__init__.py
@@ -11,12 +11,12 @@
 
 import re
 
-from pip._vendor.pygments.token import String, Comment, Keyword, Name, Error, Whitespace, \
+from fetchcode.vcs.pip._vendor.pygments.token import String, Comment, Keyword, Name, Error, Whitespace, \
     string_to_tokentype
-from pip._vendor.pygments.filter import Filter
-from pip._vendor.pygments.util import get_list_opt, get_int_opt, get_bool_opt, \
+from fetchcode.vcs.pip._vendor.pygments.filter import Filter
+from fetchcode.vcs.pip._vendor.pygments.util import get_list_opt, get_int_opt, get_bool_opt, \
     get_choice_opt, ClassNotFound, OptionError
-from pip._vendor.pygments.plugin import find_plugin_filters
+from fetchcode.vcs.pip._vendor.pygments.plugin import find_plugin_filters
 
 
 def find_filter_class(filtername):

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatter.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatter.py
@@ -10,8 +10,8 @@
 
 import codecs
 
-from pip._vendor.pygments.util import get_bool_opt
-from pip._vendor.pygments.styles import get_style_by_name
+from fetchcode.vcs.pip._vendor.pygments.util import get_bool_opt
+from fetchcode.vcs.pip._vendor.pygments.styles import get_style_by_name
 
 __all__ = ['Formatter']
 

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/__init__.py
@@ -14,9 +14,9 @@ import types
 import fnmatch
 from os.path import basename
 
-from pip._vendor.pygments.formatters._mapping import FORMATTERS
-from pip._vendor.pygments.plugin import find_plugin_formatters
-from pip._vendor.pygments.util import ClassNotFound
+from fetchcode.vcs.pip._vendor.pygments.formatters._mapping import FORMATTERS
+from fetchcode.vcs.pip._vendor.pygments.plugin import find_plugin_formatters
+from fetchcode.vcs.pip._vendor.pygments.util import ClassNotFound
 
 __all__ = ['get_formatter_by_name', 'get_formatter_for_filename',
            'get_all_formatters', 'load_formatter_from_file'] + list(FORMATTERS)

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/bbcode.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/bbcode.py
@@ -9,8 +9,8 @@
 """
 
 
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.util import get_bool_opt
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.util import get_bool_opt
 
 __all__ = ['BBCodeFormatter']
 

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/groff.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/groff.py
@@ -9,8 +9,8 @@
 """
 
 import math
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.util import get_bool_opt, get_int_opt
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.util import get_bool_opt, get_int_opt
 
 __all__ = ['GroffFormatter']
 

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/html.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/html.py
@@ -14,9 +14,9 @@ import sys
 import os.path
 from io import StringIO
 
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.token import Token, Text, STANDARD_TYPES
-from pip._vendor.pygments.util import get_bool_opt, get_int_opt, get_list_opt
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.token import Token, Text, STANDARD_TYPES
+from fetchcode.vcs.pip._vendor.pygments.util import get_bool_opt, get_int_opt, get_list_opt
 
 try:
     import ctags

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/img.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/img.py
@@ -10,8 +10,8 @@
 import os
 import sys
 
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.util import get_bool_opt, get_int_opt, get_list_opt, \
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.util import get_bool_opt, get_int_opt, get_list_opt, \
     get_choice_opt
 
 import subprocess

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/irc.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/irc.py
@@ -8,10 +8,10 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.token import Keyword, Name, Comment, String, Error, \
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.token import Keyword, Name, Comment, String, Error, \
     Number, Operator, Generic, Token, Whitespace
-from pip._vendor.pygments.util import get_choice_opt
+from fetchcode.vcs.pip._vendor.pygments.util import get_choice_opt
 
 
 __all__ = ['IRCFormatter']

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/latex.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/latex.py
@@ -10,10 +10,10 @@
 
 from io import StringIO
 
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.lexer import Lexer, do_insertions
-from pip._vendor.pygments.token import Token, STANDARD_TYPES
-from pip._vendor.pygments.util import get_bool_opt, get_int_opt
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.lexer import Lexer, do_insertions
+from fetchcode.vcs.pip._vendor.pygments.token import Token, STANDARD_TYPES
+from fetchcode.vcs.pip._vendor.pygments.util import get_bool_opt, get_int_opt
 
 
 __all__ = ['LatexFormatter']

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/other.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/other.py
@@ -8,10 +8,10 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.util import get_choice_opt
-from pip._vendor.pygments.token import Token
-from pip._vendor.pygments.console import colorize
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.util import get_choice_opt
+from fetchcode.vcs.pip._vendor.pygments.token import Token
+from fetchcode.vcs.pip._vendor.pygments.console import colorize
 
 __all__ = ['NullFormatter', 'RawTokenFormatter', 'TestcaseFormatter']
 

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/pangomarkup.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/pangomarkup.py
@@ -8,7 +8,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
 
 
 __all__ = ['PangoMarkupFormatter']

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/rtf.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/rtf.py
@@ -9,9 +9,9 @@
 """
 
 from collections import OrderedDict
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.style import _ansimap
-from pip._vendor.pygments.util import get_bool_opt, get_int_opt, get_list_opt, surrogatepair
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.style import _ansimap
+from fetchcode.vcs.pip._vendor.pygments.util import get_bool_opt, get_int_opt, get_list_opt, surrogatepair
 
 
 __all__ = ['RtfFormatter']

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/svg.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/svg.py
@@ -8,9 +8,9 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.token import Comment
-from pip._vendor.pygments.util import get_bool_opt, get_int_opt
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.token import Comment
+from fetchcode.vcs.pip._vendor.pygments.util import get_bool_opt, get_int_opt
 
 __all__ = ['SvgFormatter']
 

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/terminal.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/terminal.py
@@ -8,11 +8,11 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.token import Keyword, Name, Comment, String, Error, \
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.token import Keyword, Name, Comment, String, Error, \
     Number, Operator, Generic, Token, Whitespace
-from pip._vendor.pygments.console import ansiformat
-from pip._vendor.pygments.util import get_choice_opt
+from fetchcode.vcs.pip._vendor.pygments.console import ansiformat
+from fetchcode.vcs.pip._vendor.pygments.util import get_choice_opt
 
 
 __all__ = ['TerminalFormatter']

--- a/src/fetchcode/vcs/pip/_vendor/pygments/formatters/terminal256.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/formatters/terminal256.py
@@ -23,9 +23,9 @@
 #    black-on-while, so colors like "white background" need to be converted
 #    to "white background, black foreground", etc...
 
-from pip._vendor.pygments.formatter import Formatter
-from pip._vendor.pygments.console import codes
-from pip._vendor.pygments.style import ansicolors
+from fetchcode.vcs.pip._vendor.pygments.formatter import Formatter
+from fetchcode.vcs.pip._vendor.pygments.console import codes
+from fetchcode.vcs.pip._vendor.pygments.style import ansicolors
 
 
 __all__ = ['Terminal256Formatter', 'TerminalTrueColorFormatter']

--- a/src/fetchcode/vcs/pip/_vendor/pygments/lexer.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/lexer.py
@@ -12,12 +12,12 @@ import re
 import sys
 import time
 
-from pip._vendor.pygments.filter import apply_filters, Filter
-from pip._vendor.pygments.filters import get_filter_by_name
-from pip._vendor.pygments.token import Error, Text, Other, Whitespace, _TokenType
-from pip._vendor.pygments.util import get_bool_opt, get_int_opt, get_list_opt, \
+from fetchcode.vcs.pip._vendor.pygments.filter import apply_filters, Filter
+from fetchcode.vcs.pip._vendor.pygments.filters import get_filter_by_name
+from fetchcode.vcs.pip._vendor.pygments.token import Error, Text, Other, Whitespace, _TokenType
+from fetchcode.vcs.pip._vendor.pygments.util import get_bool_opt, get_int_opt, get_list_opt, \
     make_analysator, Future, guess_decode
-from pip._vendor.pygments.regexopt import regex_opt
+from fetchcode.vcs.pip._vendor.pygments.regexopt import regex_opt
 
 __all__ = ['Lexer', 'RegexLexer', 'ExtendedRegexLexer', 'DelegatingLexer',
            'LexerContext', 'include', 'inherit', 'bygroups', 'using', 'this',

--- a/src/fetchcode/vcs/pip/_vendor/pygments/lexers/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/lexers/__init__.py
@@ -14,10 +14,10 @@ import types
 import fnmatch
 from os.path import basename
 
-from pip._vendor.pygments.lexers._mapping import LEXERS
-from pip._vendor.pygments.modeline import get_filetype_from_buffer
-from pip._vendor.pygments.plugin import find_plugin_lexers
-from pip._vendor.pygments.util import ClassNotFound, guess_decode
+from fetchcode.vcs.pip._vendor.pygments.lexers._mapping import LEXERS
+from fetchcode.vcs.pip._vendor.pygments.modeline import get_filetype_from_buffer
+from fetchcode.vcs.pip._vendor.pygments.plugin import find_plugin_lexers
+from fetchcode.vcs.pip._vendor.pygments.util import ClassNotFound, guess_decode
 
 COMPAT = {
     'Python3Lexer': 'PythonLexer',

--- a/src/fetchcode/vcs/pip/_vendor/pygments/lexers/python.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/lexers/python.py
@@ -10,12 +10,12 @@
 
 import keyword
 
-from pip._vendor.pygments.lexer import DelegatingLexer, RegexLexer, include, \
+from fetchcode.vcs.pip._vendor.pygments.lexer import DelegatingLexer, RegexLexer, include, \
     bygroups, using, default, words, combined, this
-from pip._vendor.pygments.util import get_bool_opt, shebang_matches
-from pip._vendor.pygments.token import Text, Comment, Operator, Keyword, Name, String, \
+from fetchcode.vcs.pip._vendor.pygments.util import get_bool_opt, shebang_matches
+from fetchcode.vcs.pip._vendor.pygments.token import Text, Comment, Operator, Keyword, Name, String, \
     Number, Punctuation, Generic, Other, Error, Whitespace
-from pip._vendor.pygments import unistring as uni
+from fetchcode.vcs.pip._vendor.pygments import unistring as uni
 
 __all__ = ['PythonLexer', 'PythonConsoleLexer', 'PythonTracebackLexer',
            'Python2Lexer', 'Python2TracebackLexer',

--- a/src/fetchcode/vcs/pip/_vendor/pygments/sphinxext.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/sphinxext.py
@@ -92,8 +92,8 @@ class PygmentsDoc(Directive):
 
         The columns are the lexer name, the extensions handled by this lexer
         (or "None"), the aliases and a link to the lexer class."""
-        from pip._vendor.pygments.lexers._mapping import LEXERS
-        from pip._vendor.pygments.lexers import find_lexer_class
+        from fetchcode.vcs.pip._vendor.pygments.lexers._mapping import LEXERS
+        from fetchcode.vcs.pip._vendor.pygments.lexers import find_lexer_class
         out = []
 
         table = []
@@ -148,8 +148,8 @@ class PygmentsDoc(Directive):
         return '\n'.join(out)
 
     def document_lexers(self):
-        from pip._vendor.pygments.lexers._mapping import LEXERS
-        from pip._vendor import pygments
+        from fetchcode.vcs.pip._vendor.pygments.lexers._mapping import LEXERS
+        from fetchcode.vcs.pip._vendor import pygments
         import inspect
         import pathlib
 
@@ -213,7 +213,7 @@ class PygmentsDoc(Directive):
         return ''.join(out)
 
     def document_formatters(self):
-        from pip._vendor.pygments.formatters import FORMATTERS
+        from fetchcode.vcs.pip._vendor.pygments.formatters import FORMATTERS
 
         out = []
         for classname, data in sorted(FORMATTERS.items(), key=lambda x: x[0]):
@@ -231,7 +231,7 @@ class PygmentsDoc(Directive):
         return ''.join(out)
 
     def document_filters(self):
-        from pip._vendor.pygments.filters import FILTERS
+        from fetchcode.vcs.pip._vendor.pygments.filters import FILTERS
 
         out = []
         for name, cls in FILTERS.items():

--- a/src/fetchcode/vcs/pip/_vendor/pygments/style.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/style.py
@@ -8,7 +8,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pip._vendor.pygments.token import Token, STANDARD_TYPES
+from fetchcode.vcs.pip._vendor.pygments.token import Token, STANDARD_TYPES
 
 # Default mapping of ansixxx to RGB colors.
 _ansimap = {

--- a/src/fetchcode/vcs/pip/_vendor/pygments/styles/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/pygments/styles/__init__.py
@@ -8,9 +8,9 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pip._vendor.pygments.plugin import find_plugin_styles
-from pip._vendor.pygments.util import ClassNotFound
-from pip._vendor.pygments.styles._mapping import STYLES
+from fetchcode.vcs.pip._vendor.pygments.plugin import find_plugin_styles
+from fetchcode.vcs.pip._vendor.pygments.util import ClassNotFound
+from fetchcode.vcs.pip._vendor.pygments.styles._mapping import STYLES
 
 #: A dictionary of built-in styles, mapping style names to
 #: ``'submodule::classname'`` strings.

--- a/src/fetchcode/vcs/pip/_vendor/pyproject_hooks/_compat.py
+++ b/src/fetchcode/vcs/pip/_vendor/pyproject_hooks/_compat.py
@@ -5,4 +5,4 @@ import sys
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    from pip._vendor import tomli as tomllib
+    from fetchcode.vcs.pip._vendor import tomli as tomllib

--- a/src/fetchcode/vcs/pip/_vendor/requests/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/requests/__init__.py
@@ -40,7 +40,7 @@ is at <https://requests.readthedocs.io>.
 
 import warnings
 
-from pip._vendor import urllib3
+from fetchcode.vcs.pip._vendor import urllib3
 
 from .exceptions import RequestsDependencyWarning
 
@@ -114,7 +114,7 @@ except (AssertionError, ValueError):
 try:
     # Note: This logic prevents upgrading cryptography on Windows, if imported
     #       as part of pip.
-    from pip._internal.utils.compat import WINDOWS
+    from fetchcode.vcs.pip._internal.utils.compat import WINDOWS
     if not WINDOWS:
         raise ImportError("pip internals: don't import cryptography on Windows")
     try:
@@ -123,7 +123,7 @@ try:
         ssl = None
 
     if not getattr(ssl, "HAS_SNI", False):
-        from pip._vendor.urllib3.contrib import pyopenssl
+        from fetchcode.vcs.pip._vendor.urllib3.contrib import pyopenssl
 
         pyopenssl.inject_into_urllib3()
 
@@ -135,7 +135,7 @@ except ImportError:
     pass
 
 # urllib3's DependencyWarnings should be silenced.
-from pip._vendor.urllib3.exceptions import DependencyWarning
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import DependencyWarning
 
 warnings.simplefilter("ignore", DependencyWarning)
 

--- a/src/fetchcode/vcs/pip/_vendor/requests/adapters.py
+++ b/src/fetchcode/vcs/pip/_vendor/requests/adapters.py
@@ -11,23 +11,23 @@ import socket  # noqa: F401
 import typing
 import warnings
 
-from pip._vendor.urllib3.exceptions import ClosedPoolError, ConnectTimeoutError
-from pip._vendor.urllib3.exceptions import HTTPError as _HTTPError
-from pip._vendor.urllib3.exceptions import InvalidHeader as _InvalidHeader
-from pip._vendor.urllib3.exceptions import (
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import ClosedPoolError, ConnectTimeoutError
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import HTTPError as _HTTPError
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import InvalidHeader as _InvalidHeader
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import (
     LocationValueError,
     MaxRetryError,
     NewConnectionError,
     ProtocolError,
 )
-from pip._vendor.urllib3.exceptions import ProxyError as _ProxyError
-from pip._vendor.urllib3.exceptions import ReadTimeoutError, ResponseError
-from pip._vendor.urllib3.exceptions import SSLError as _SSLError
-from pip._vendor.urllib3.poolmanager import PoolManager, proxy_from_url
-from pip._vendor.urllib3.util import Timeout as TimeoutSauce
-from pip._vendor.urllib3.util import parse_url
-from pip._vendor.urllib3.util.retry import Retry
-from pip._vendor.urllib3.util.ssl_ import create_urllib3_context
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import ProxyError as _ProxyError
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import ReadTimeoutError, ResponseError
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import SSLError as _SSLError
+from fetchcode.vcs.pip._vendor.urllib3.poolmanager import PoolManager, proxy_from_url
+from fetchcode.vcs.pip._vendor.urllib3.util import Timeout as TimeoutSauce
+from fetchcode.vcs.pip._vendor.urllib3.util import parse_url
+from fetchcode.vcs.pip._vendor.urllib3.util.retry import Retry
+from fetchcode.vcs.pip._vendor.urllib3.util.ssl_ import create_urllib3_context
 
 from .auth import _basic_auth_str
 from .compat import basestring, urlparse
@@ -57,7 +57,7 @@ from .utils import (
 )
 
 try:
-    from pip._vendor.urllib3.contrib.socks import SOCKSProxyManager
+    from fetchcode.vcs.pip._vendor.urllib3.contrib.socks import SOCKSProxyManager
 except ImportError:
 
     def SOCKSProxyManager(*args, **kwargs):

--- a/src/fetchcode/vcs/pip/_vendor/requests/certs.py
+++ b/src/fetchcode/vcs/pip/_vendor/requests/certs.py
@@ -15,7 +15,7 @@ packaged CA bundle.
 import os
 
 if "_PIP_STANDALONE_CERT" not in os.environ:
-    from pip._vendor.certifi import where
+    from fetchcode.vcs.pip._vendor.certifi import where
 else:
     def where():
         return os.environ["_PIP_STANDALONE_CERT"]

--- a/src/fetchcode/vcs/pip/_vendor/requests/exceptions.py
+++ b/src/fetchcode/vcs/pip/_vendor/requests/exceptions.py
@@ -4,7 +4,7 @@ requests.exceptions
 
 This module contains the set of Requests' exceptions.
 """
-from pip._vendor.urllib3.exceptions import HTTPError as BaseHTTPError
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import HTTPError as BaseHTTPError
 
 from .compat import JSONDecodeError as CompatJSONDecodeError
 

--- a/src/fetchcode/vcs/pip/_vendor/requests/help.py
+++ b/src/fetchcode/vcs/pip/_vendor/requests/help.py
@@ -5,8 +5,8 @@ import platform
 import ssl
 import sys
 
-from pip._vendor import idna
-from pip._vendor import urllib3
+from fetchcode.vcs.pip._vendor import idna
+from fetchcode.vcs.pip._vendor import urllib3
 
 from . import __version__ as requests_version
 
@@ -14,7 +14,7 @@ charset_normalizer = None
 chardet = None
 
 try:
-    from pip._vendor.urllib3.contrib import pyopenssl
+    from fetchcode.vcs.pip._vendor.urllib3.contrib import pyopenssl
 except ImportError:
     pyopenssl = None
     OpenSSL = None

--- a/src/fetchcode/vcs/pip/_vendor/requests/models.py
+++ b/src/fetchcode/vcs/pip/_vendor/requests/models.py
@@ -13,16 +13,16 @@ import datetime
 import encodings.idna  # noqa: F401
 from io import UnsupportedOperation
 
-from pip._vendor.urllib3.exceptions import (
+from fetchcode.vcs.pip._vendor.urllib3.exceptions import (
     DecodeError,
     LocationParseError,
     ProtocolError,
     ReadTimeoutError,
     SSLError,
 )
-from pip._vendor.urllib3.fields import RequestField
-from pip._vendor.urllib3.filepost import encode_multipart_formdata
-from pip._vendor.urllib3.util import parse_url
+from fetchcode.vcs.pip._vendor.urllib3.fields import RequestField
+from fetchcode.vcs.pip._vendor.urllib3.filepost import encode_multipart_formdata
+from fetchcode.vcs.pip._vendor.urllib3.util import parse_url
 
 from ._internal_utils import to_native_string, unicode_is_ascii
 from .auth import HTTPBasicAuth
@@ -398,7 +398,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
 
     @staticmethod
     def _get_idna_encoded_host(host):
-        from pip._vendor import idna
+        from fetchcode.vcs.pip._vendor import idna
 
         try:
             host = idna.encode(host, uts46=True).decode("utf-8")

--- a/src/fetchcode/vcs/pip/_vendor/requests/utils.py
+++ b/src/fetchcode/vcs/pip/_vendor/requests/utils.py
@@ -19,7 +19,7 @@ import warnings
 import zipfile
 from collections import OrderedDict
 
-from pip._vendor.urllib3.util import make_headers, parse_url
+from fetchcode.vcs.pip._vendor.urllib3.util import make_headers, parse_url
 
 from . import certs
 from .__version__ import __version__

--- a/src/fetchcode/vcs/pip/_vendor/rich/__init__.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/__init__.py
@@ -43,7 +43,7 @@ def reconfigure(*args: Any, **kwargs: Any) -> None:
         *args (Any): Positional arguments for the replacement :class:`~rich.console.Console`.
         **kwargs (Any): Keyword arguments for the replacement :class:`~rich.console.Console`.
     """
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     new_console = Console(*args, **kwargs)
     _console = get_console()
@@ -153,7 +153,7 @@ def inspect(
         value (bool, optional): Pretty print value. Defaults to True.
     """
     _console = console or get_console()
-    from pip._vendor.rich._inspect import Inspect
+    from fetchcode.vcs.pip._vendor.rich._inspect import Inspect
 
     # Special case for inspect(inspect)
     is_inspect = obj is inspect

--- a/src/fetchcode/vcs/pip/_vendor/rich/__main__.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/__main__.py
@@ -2,17 +2,17 @@ import colorsys
 import io
 from time import process_time
 
-from pip._vendor.rich import box
-from pip._vendor.rich.color import Color
-from pip._vendor.rich.console import Console, ConsoleOptions, Group, RenderableType, RenderResult
-from pip._vendor.rich.markdown import Markdown
-from pip._vendor.rich.measure import Measurement
-from pip._vendor.rich.pretty import Pretty
-from pip._vendor.rich.segment import Segment
-from pip._vendor.rich.style import Style
-from pip._vendor.rich.syntax import Syntax
-from pip._vendor.rich.table import Table
-from pip._vendor.rich.text import Text
+from fetchcode.vcs.pip._vendor.rich import box
+from fetchcode.vcs.pip._vendor.rich.color import Color
+from fetchcode.vcs.pip._vendor.rich.console import Console, ConsoleOptions, Group, RenderableType, RenderResult
+from fetchcode.vcs.pip._vendor.rich.markdown import Markdown
+from fetchcode.vcs.pip._vendor.rich.measure import Measurement
+from fetchcode.vcs.pip._vendor.rich.pretty import Pretty
+from fetchcode.vcs.pip._vendor.rich.segment import Segment
+from fetchcode.vcs.pip._vendor.rich.style import Style
+from fetchcode.vcs.pip._vendor.rich.syntax import Syntax
+from fetchcode.vcs.pip._vendor.rich.table import Table
+from fetchcode.vcs.pip._vendor.rich.text import Text
 
 
 class ColorBox:
@@ -230,7 +230,7 @@ if __name__ == "__main__":  # pragma: no cover
     print(f"rendered in {pre_cache_taken}ms (cold cache)")
     print(f"rendered in {taken}ms (warm cache)")
 
-    from pip._vendor.rich.panel import Panel
+    from fetchcode.vcs.pip._vendor.rich.panel import Panel
 
     console = Console()
 

--- a/src/fetchcode/vcs/pip/_vendor/rich/_extension.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/_extension.py
@@ -3,8 +3,8 @@ from typing import Any
 
 def load_ipython_extension(ip: Any) -> None:  # pragma: no cover
     # prevent circular import
-    from pip._vendor.rich.pretty import install
-    from pip._vendor.rich.traceback import install as tr_install
+    from fetchcode.vcs.pip._vendor.rich.pretty import install
+    from fetchcode.vcs.pip._vendor.rich.traceback import install as tr_install
 
     install()
     tr_install()

--- a/src/fetchcode/vcs/pip/_vendor/rich/_log_render.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/_log_render.py
@@ -87,7 +87,7 @@ class LogRender:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     c = Console()
     c.print("[on blue]Hello", justify="right")

--- a/src/fetchcode/vcs/pip/_vendor/rich/_ratio.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/_ratio.py
@@ -6,7 +6,7 @@ from typing import cast, List, Optional, Sequence
 if sys.version_info >= (3, 8):
     from typing import Protocol
 else:
-    from pip._vendor.typing_extensions import Protocol  # pragma: no cover
+    from fetchcode.vcs.pip._vendor.typing_extensions import Protocol  # pragma: no cover
 
 
 class Edge(Protocol):

--- a/src/fetchcode/vcs/pip/_vendor/rich/_win32_console.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/_win32_console.py
@@ -16,8 +16,8 @@ import time
 from ctypes import Structure, byref, wintypes
 from typing import IO, NamedTuple, Type, cast
 
-from pip._vendor.rich.color import ColorSystem
-from pip._vendor.rich.style import Style
+from fetchcode.vcs.pip._vendor.rich.color import ColorSystem
+from fetchcode.vcs.pip._vendor.rich.style import Style
 
 STDOUT = -11
 ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4
@@ -576,7 +576,7 @@ class LegacyWindowsTerm:
 if __name__ == "__main__":
     handle = GetStdHandle()
 
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     console = Console()
 

--- a/src/fetchcode/vcs/pip/_vendor/rich/_windows.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/_windows.py
@@ -22,7 +22,7 @@ try:
         windll = None
         raise ImportError("Not windows")
 
-    from pip._vendor.rich._win32_console import (
+    from fetchcode.vcs.pip._vendor.rich._win32_console import (
         ENABLE_VIRTUAL_TERMINAL_PROCESSING,
         GetConsoleMode,
         GetStdHandle,
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     import platform
 
     features = get_windows_console_features()
-    from pip._vendor.rich import print
+    from fetchcode.vcs.pip._vendor.rich import print
 
     print(f'platform="{platform.system()}"')
     print(repr(features))

--- a/src/fetchcode/vcs/pip/_vendor/rich/_windows_renderer.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/_windows_renderer.py
@@ -1,7 +1,7 @@
 from typing import Iterable, Sequence, Tuple, cast
 
-from pip._vendor.rich._win32_console import LegacyWindowsTerm, WindowsCoordinates
-from pip._vendor.rich.segment import ControlCode, ControlType, Segment
+from fetchcode.vcs.pip._vendor.rich._win32_console import LegacyWindowsTerm, WindowsCoordinates
+from fetchcode.vcs.pip._vendor.rich.segment import ControlCode, ControlType, Segment
 
 
 def legacy_windows_render(buffer: Iterable[Segment], term: LegacyWindowsTerm) -> None:

--- a/src/fetchcode/vcs/pip/_vendor/rich/abc.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/abc.py
@@ -19,7 +19,7 @@ class RichRenderable(ABC):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich.text import Text
+    from fetchcode.vcs.pip._vendor.rich.text import Text
 
     t = Text()
     print(isinstance(Text, RichRenderable))

--- a/src/fetchcode/vcs/pip/_vendor/rich/align.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/align.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Iterable, Optional
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from pip._vendor.typing_extensions import Literal  # pragma: no cover
+    from fetchcode.vcs.pip._vendor.typing_extensions import Literal  # pragma: no cover
 
 from .constrain import Constrain
 from .jupyter import JupyterMixin
@@ -288,9 +288,9 @@ class VerticalCenter(JupyterMixin):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich.console import Console, Group
-    from pip._vendor.rich.highlighter import ReprHighlighter
-    from pip._vendor.rich.panel import Panel
+    from fetchcode.vcs.pip._vendor.rich.console import Console, Group
+    from fetchcode.vcs.pip._vendor.rich.highlighter import ReprHighlighter
+    from fetchcode.vcs.pip._vendor.rich.panel import Panel
 
     highlighter = ReprHighlighter()
     console = Console()

--- a/src/fetchcode/vcs/pip/_vendor/rich/box.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/box.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING, Iterable, List
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from pip._vendor.typing_extensions import Literal  # pragma: no cover
+    from fetchcode.vcs.pip._vendor.typing_extensions import Literal  # pragma: no cover
 
 
 from ._loop import loop_last
 
 if TYPE_CHECKING:
-    from pip._vendor.rich.console import ConsoleOptions
+    from fetchcode.vcs.pip._vendor.rich.console import ConsoleOptions
 
 
 class Box:
@@ -428,8 +428,8 @@ PLAIN_HEADED_SUBSTITUTIONS = {
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich.columns import Columns
-    from pip._vendor.rich.panel import Panel
+    from fetchcode.vcs.pip._vendor.rich.columns import Columns
+    from fetchcode.vcs.pip._vendor.rich.panel import Panel
 
     from . import box as box
     from .console import Console

--- a/src/fetchcode/vcs/pip/_vendor/rich/console.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/console.py
@@ -33,12 +33,12 @@ from typing import (
     cast,
 )
 
-from pip._vendor.rich._null_file import NULL_FILE
+from fetchcode.vcs.pip._vendor.rich._null_file import NULL_FILE
 
 if sys.version_info >= (3, 8):
     from typing import Literal, Protocol, runtime_checkable
 else:
-    from pip._vendor.typing_extensions import (
+    from fetchcode.vcs.pip._vendor.typing_extensions import (
         Literal,
         Protocol,
         runtime_checkable,
@@ -1749,7 +1749,7 @@ class Console:
                 in to something that can be JSON encoded. Defaults to None.
             sort_keys (bool, optional): Sort dictionary keys. Defaults to False.
         """
-        from pip._vendor.rich.json import JSON
+        from fetchcode.vcs.pip._vendor.rich.json import JSON
 
         if json is None:
             json_renderable = JSON.from_data(
@@ -2017,8 +2017,8 @@ class Console:
                                 )
 
                         if use_legacy_windows_render:
-                            from pip._vendor.rich._win32_console import LegacyWindowsTerm
-                            from pip._vendor.rich._windows_renderer import legacy_windows_render
+                            from fetchcode.vcs.pip._vendor.rich._win32_console import LegacyWindowsTerm
+                            from fetchcode.vcs.pip._vendor.rich._windows_renderer import legacy_windows_render
 
                             buffer = self._buffer[:]
                             if self.no_color and self._color_system:
@@ -2302,7 +2302,7 @@ class Console:
                 ids). If not set, this defaults to a computed value based on the recorded content.
         """
 
-        from pip._vendor.rich.cells import cell_len
+        from fetchcode.vcs.pip._vendor.rich.cells import cell_len
 
         style_cache: Dict[Style, str] = {}
 

--- a/src/fetchcode/vcs/pip/_vendor/rich/control.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/control.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Union
 if sys.version_info >= (3, 8):
     from typing import Final
 else:
-    from pip._vendor.typing_extensions import Final  # pragma: no cover
+    from fetchcode.vcs.pip._vendor.typing_extensions import Final  # pragma: no cover
 
 from .segment import ControlCode, ControlType, Segment
 
@@ -215,7 +215,7 @@ def escape_control_codes(
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     console = Console()
     console.print("Look at the title of your terminal window ^")

--- a/src/fetchcode/vcs/pip/_vendor/rich/default_styles.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/default_styles.py
@@ -170,9 +170,9 @@ if __name__ == "__main__":  # pragma: no cover
     import argparse
     import io
 
-    from pip._vendor.rich.console import Console
-    from pip._vendor.rich.table import Table
-    from pip._vendor.rich.text import Text
+    from fetchcode.vcs.pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.table import Table
+    from fetchcode.vcs.pip._vendor.rich.text import Text
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--html", action="store_true", help="Export as HTML table")

--- a/src/fetchcode/vcs/pip/_vendor/rich/diagnose.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/diagnose.py
@@ -1,10 +1,10 @@
 import os
 import platform
 
-from pip._vendor.rich import inspect
-from pip._vendor.rich.console import Console, get_windows_console_features
-from pip._vendor.rich.panel import Panel
-from pip._vendor.rich.pretty import Pretty
+from fetchcode.vcs.pip._vendor.rich import inspect
+from fetchcode.vcs.pip._vendor.rich.console import Console, get_windows_console_features
+from fetchcode.vcs.pip._vendor.rich.panel import Panel
+from fetchcode.vcs.pip._vendor.rich.pretty import Pretty
 
 
 def report() -> None:  # pragma: no cover

--- a/src/fetchcode/vcs/pip/_vendor/rich/emoji.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/emoji.py
@@ -10,7 +10,7 @@ from ._emoji_replace import _emoji_replace
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from pip._vendor.typing_extensions import Literal  # pragma: no cover
+    from fetchcode.vcs.pip._vendor.typing_extensions import Literal  # pragma: no cover
 
 
 if TYPE_CHECKING:
@@ -81,8 +81,8 @@ class Emoji(JupyterMixin):
 if __name__ == "__main__":  # pragma: no cover
     import sys
 
-    from pip._vendor.rich.columns import Columns
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.columns import Columns
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     console = Console(record=True)
 

--- a/src/fetchcode/vcs/pip/_vendor/rich/json.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/json.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     console = Console()
     error_console = Console(stderr=True)

--- a/src/fetchcode/vcs/pip/_vendor/rich/jupyter.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/jupyter.py
@@ -1,14 +1,14 @@
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Sequence
 
 if TYPE_CHECKING:
-    from pip._vendor.rich.console import ConsoleRenderable
+    from fetchcode.vcs.pip._vendor.rich.console import ConsoleRenderable
 
 from . import get_console
 from .segment import Segment
 from .terminal_theme import DEFAULT_TERMINAL_THEME
 
 if TYPE_CHECKING:
-    from pip._vendor.rich.console import ConsoleRenderable
+    from fetchcode.vcs.pip._vendor.rich.console import ConsoleRenderable
 
 JUPYTER_HTML_FORMAT = """\
 <pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace">{code}</pre>

--- a/src/fetchcode/vcs/pip/_vendor/rich/layout.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/layout.py
@@ -26,7 +26,7 @@ from .segment import Segment
 from .style import StyleType
 
 if TYPE_CHECKING:
-    from pip._vendor.rich.tree import Tree
+    from fetchcode.vcs.pip._vendor.rich.tree import Tree
 
 
 class LayoutRender(NamedTuple):
@@ -222,9 +222,9 @@ class Layout:
     @property
     def tree(self) -> "Tree":
         """Get a tree renderable to show layout structure."""
-        from pip._vendor.rich.styled import Styled
-        from pip._vendor.rich.table import Table
-        from pip._vendor.rich.tree import Tree
+        from fetchcode.vcs.pip._vendor.rich.styled import Styled
+        from fetchcode.vcs.pip._vendor.rich.table import Table
+        from fetchcode.vcs.pip._vendor.rich.tree import Tree
 
         def summary(layout: "Layout") -> Table:
             icon = layout.splitter.get_tree_icon()
@@ -416,7 +416,7 @@ class Layout:
 
 
 if __name__ == "__main__":
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     console = Console()
     layout = Layout()

--- a/src/fetchcode/vcs/pip/_vendor/rich/live_render.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/live_render.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from pip._vendor.typing_extensions import Literal  # pragma: no cover
+    from fetchcode.vcs.pip._vendor.typing_extensions import Literal  # pragma: no cover
 
 
 from ._loop import loop_last

--- a/src/fetchcode/vcs/pip/_vendor/rich/logging.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/logging.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import ClassVar, Iterable, List, Optional, Type, Union
 
-from pip._vendor.rich._null_file import NullFile
+from fetchcode.vcs.pip._vendor.rich._null_file import NullFile
 
 from . import get_console
 from ._log_render import FormatTimeCallable, LogRender

--- a/src/fetchcode/vcs/pip/_vendor/rich/markup.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/markup.py
@@ -240,8 +240,8 @@ if __name__ == "__main__":  # pragma: no cover
         ":warning-emoji: [bold red blink] DANGER![/]",
     ]
 
-    from pip._vendor.rich import print
-    from pip._vendor.rich.table import Table
+    from fetchcode.vcs.pip._vendor.rich import print
+    from fetchcode.vcs.pip._vendor.rich.table import Table
 
     grid = Table("Markup", "Result", padding=(0, 1))
 

--- a/src/fetchcode/vcs/pip/_vendor/rich/padding.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/padding.py
@@ -136,6 +136,6 @@ class Padding(JupyterMixin):
 
 
 if __name__ == "__main__":  #  pragma: no cover
-    from pip._vendor.rich import print
+    from fetchcode.vcs.pip._vendor.rich import print
 
     print(Padding("Hello, World", (2, 4), style="on blue"))

--- a/src/fetchcode/vcs/pip/_vendor/rich/palette.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/palette.py
@@ -5,7 +5,7 @@ from typing import Sequence, Tuple, TYPE_CHECKING
 from .color_triplet import ColorTriplet
 
 if TYPE_CHECKING:
-    from pip._vendor.rich.table import Table
+    from fetchcode.vcs.pip._vendor.rich.table import Table
 
 
 class Palette:
@@ -18,10 +18,10 @@ class Palette:
         return ColorTriplet(*self._colors[number])
 
     def __rich__(self) -> "Table":
-        from pip._vendor.rich.color import Color
-        from pip._vendor.rich.style import Style
-        from pip._vendor.rich.text import Text
-        from pip._vendor.rich.table import Table
+        from fetchcode.vcs.pip._vendor.rich.color import Color
+        from fetchcode.vcs.pip._vendor.rich.style import Style
+        from fetchcode.vcs.pip._vendor.rich.text import Text
+        from fetchcode.vcs.pip._vendor.rich.table import Table
 
         table = Table(
             "index",
@@ -75,10 +75,10 @@ class Palette:
 if __name__ == "__main__":  # pragma: no cover
     import colorsys
     from typing import Iterable
-    from pip._vendor.rich.color import Color
-    from pip._vendor.rich.console import Console, ConsoleOptions
-    from pip._vendor.rich.segment import Segment
-    from pip._vendor.rich.style import Style
+    from fetchcode.vcs.pip._vendor.rich.color import Color
+    from fetchcode.vcs.pip._vendor.rich.console import Console, ConsoleOptions
+    from fetchcode.vcs.pip._vendor.rich.segment import Segment
+    from fetchcode.vcs.pip._vendor.rich.style import Style
 
     class ColorBox:
         def __rich_console__(

--- a/src/fetchcode/vcs/pip/_vendor/rich/pretty.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/pretty.py
@@ -25,7 +25,7 @@ from typing import (
     Union,
 )
 
-from pip._vendor.rich.repr import RichReprResult
+from fetchcode.vcs.pip._vendor.rich.repr import RichReprResult
 
 try:
     import attr as _attr_module
@@ -185,7 +185,7 @@ def install(
         expand_all (bool, optional): Expand all containers. Defaults to False.
         max_frames (int): Maximum number of frames to show in a traceback, 0 for no maximum. Defaults to 100.
     """
-    from pip._vendor.rich import get_console
+    from fetchcode.vcs.pip._vendor.rich import get_console
 
     console = console or get_console()
     assert console is not None
@@ -984,7 +984,7 @@ if __name__ == "__main__":  # pragma: no cover
     }
     data["foo"].append(data)  # type: ignore[attr-defined]
 
-    from pip._vendor.rich import print
+    from fetchcode.vcs.pip._vendor.rich import print
 
     print(Pretty(data, indent_guides=True, max_string=20))
 

--- a/src/fetchcode/vcs/pip/_vendor/rich/progress.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/progress.py
@@ -37,7 +37,7 @@ from typing import (
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from pip._vendor.typing_extensions import Literal  # pragma: no cover
+    from fetchcode.vcs.pip._vendor.typing_extensions import Literal  # pragma: no cover
 
 from . import filesize, get_console
 from .console import Console, Group, JustifyMethod, RenderableType

--- a/src/fetchcode/vcs/pip/_vendor/rich/prompt.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/prompt.py
@@ -346,7 +346,7 @@ class Confirm(PromptBase[bool]):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich import print
+    from fetchcode.vcs.pip._vendor.rich import print
 
     if Confirm.ask("Run [i]prompt[/i] tests?", default=True):
         while True:

--- a/src/fetchcode/vcs/pip/_vendor/rich/protocol.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/protocol.py
@@ -2,7 +2,7 @@ from typing import Any, cast, Set, TYPE_CHECKING
 from inspect import isclass
 
 if TYPE_CHECKING:
-    from pip._vendor.rich.console import RenderableType
+    from fetchcode.vcs.pip._vendor.rich.console import RenderableType
 
 _GIBBERISH = """aihwerij235234ljsdnp34ksodfipwoe234234jlskjdf"""
 
@@ -25,7 +25,7 @@ def rich_cast(renderable: object) -> "RenderableType":
     Returns:
         object: The result of recursively calling __rich__.
     """
-    from pip._vendor.rich.console import RenderableType
+    from fetchcode.vcs.pip._vendor.rich.console import RenderableType
 
     rich_visited_set: Set[type] = set()  # Prevent potential infinite loop
     while hasattr(renderable, "__rich__") and not isclass(renderable):

--- a/src/fetchcode/vcs/pip/_vendor/rich/repr.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/repr.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
             yield "buy", "hand sanitizer"
 
     foo = Foo()
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     console = Console()
 

--- a/src/fetchcode/vcs/pip/_vendor/rich/rule.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/rule.py
@@ -117,7 +117,7 @@ class Rule(JupyterMixin):
 if __name__ == "__main__":  # pragma: no cover
     import sys
 
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     try:
         text = sys.argv[1]

--- a/src/fetchcode/vcs/pip/_vendor/rich/scope.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/scope.py
@@ -68,7 +68,7 @@ def render_scope(
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich import print
+    from fetchcode.vcs.pip._vendor.rich import print
 
     print()
 

--- a/src/fetchcode/vcs/pip/_vendor/rich/screen.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/screen.py
@@ -31,7 +31,7 @@ class Screen:
         style: Optional[StyleType] = None,
         application_mode: bool = False,
     ) -> None:
-        from pip._vendor.rich.console import Group
+        from fetchcode.vcs.pip._vendor.rich.console import Group
 
         self.renderable = Group(*renderables)
         self.style = style

--- a/src/fetchcode/vcs/pip/_vendor/rich/segment.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/segment.py
@@ -705,9 +705,9 @@ class SegmentLines:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich.console import Console
-    from pip._vendor.rich.syntax import Syntax
-    from pip._vendor.rich.text import Text
+    from fetchcode.vcs.pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.syntax import Syntax
+    from fetchcode.vcs.pip._vendor.rich.text import Text
 
     code = """from rich.console import Console
 console = Console()

--- a/src/fetchcode/vcs/pip/_vendor/rich/styled.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/styled.py
@@ -35,8 +35,8 @@ class Styled:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich import print
-    from pip._vendor.rich.panel import Panel
+    from fetchcode.vcs.pip._vendor.rich import print
+    from fetchcode.vcs.pip._vendor.rich.panel import Panel
 
     panel = Styled(Panel("hello"), "on blue")
     print(panel)

--- a/src/fetchcode/vcs/pip/_vendor/rich/syntax.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/syntax.py
@@ -19,11 +19,11 @@ from typing import (
     Union,
 )
 
-from pip._vendor.pygments.lexer import Lexer
-from pip._vendor.pygments.lexers import get_lexer_by_name, guess_lexer_for_filename
-from pip._vendor.pygments.style import Style as PygmentsStyle
-from pip._vendor.pygments.styles import get_style_by_name
-from pip._vendor.pygments.token import (
+from fetchcode.vcs.pip._vendor.pygments.lexer import Lexer
+from fetchcode.vcs.pip._vendor.pygments.lexers import get_lexer_by_name, guess_lexer_for_filename
+from fetchcode.vcs.pip._vendor.pygments.style import Style as PygmentsStyle
+from fetchcode.vcs.pip._vendor.pygments.styles import get_style_by_name
+from fetchcode.vcs.pip._vendor.pygments.token import (
     Comment,
     Error,
     Generic,
@@ -35,10 +35,10 @@ from pip._vendor.pygments.token import (
     Token,
     Whitespace,
 )
-from pip._vendor.pygments.util import ClassNotFound
+from fetchcode.vcs.pip._vendor.pygments.util import ClassNotFound
 
-from pip._vendor.rich.containers import Lines
-from pip._vendor.rich.padding import Padding, PaddingDimensions
+from fetchcode.vcs.pip._vendor.rich.containers import Lines
+from fetchcode.vcs.pip._vendor.rich.padding import Padding, PaddingDimensions
 
 from ._loop import loop_first
 from .cells import cell_len
@@ -926,7 +926,7 @@ if __name__ == "__main__":  # pragma: no cover
     )
     args = parser.parse_args()
 
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     console = Console(force_terminal=args.force_color, width=args.width)
 

--- a/src/fetchcode/vcs/pip/_vendor/rich/table.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/table.py
@@ -920,9 +920,9 @@ class Table(JupyterMixin):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich.console import Console
-    from pip._vendor.rich.highlighter import ReprHighlighter
-    from pip._vendor.rich.table import Table as Table
+    from fetchcode.vcs.pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.highlighter import ReprHighlighter
+    from fetchcode.vcs.pip._vendor.rich.table import Table as Table
 
     from ._timer import timer
 

--- a/src/fetchcode/vcs/pip/_vendor/rich/text.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/text.py
@@ -1330,7 +1330,7 @@ class Text(JupyterMixin):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich.console import Console
+    from fetchcode.vcs.pip._vendor.rich.console import Console
 
     text = Text(
         """\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"""

--- a/src/fetchcode/vcs/pip/_vendor/rich/traceback.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/traceback.py
@@ -20,11 +20,11 @@ from typing import (
     Union,
 )
 
-from pip._vendor.pygments.lexers import guess_lexer_for_filename
-from pip._vendor.pygments.token import Comment, Keyword, Name, Number, Operator, String
-from pip._vendor.pygments.token import Text as TextToken
-from pip._vendor.pygments.token import Token
-from pip._vendor.pygments.util import ClassNotFound
+from fetchcode.vcs.pip._vendor.pygments.lexers import guess_lexer_for_filename
+from fetchcode.vcs.pip._vendor.pygments.token import Comment, Keyword, Name, Number, Operator, String
+from fetchcode.vcs.pip._vendor.pygments.token import Text as TextToken
+from fetchcode.vcs.pip._vendor.pygments.token import Token
+from fetchcode.vcs.pip._vendor.pygments.util import ClassNotFound
 
 from . import pretty
 from ._loop import loop_last
@@ -392,7 +392,7 @@ class Traceback:
         stacks: List[Stack] = []
         is_cause = False
 
-        from pip._vendor.rich import _IMPORT_CWD
+        from fetchcode.vcs.pip._vendor.rich import _IMPORT_CWD
 
         def safe_str(_object: Any) -> str:
             """Don't allow exceptions from __str__ to propagate."""

--- a/src/fetchcode/vcs/pip/_vendor/rich/tree.py
+++ b/src/fetchcode/vcs/pip/_vendor/rich/tree.py
@@ -194,11 +194,11 @@ class Tree(JupyterMixin):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from pip._vendor.rich.console import Group
-    from pip._vendor.rich.markdown import Markdown
-    from pip._vendor.rich.panel import Panel
-    from pip._vendor.rich.syntax import Syntax
-    from pip._vendor.rich.table import Table
+    from fetchcode.vcs.pip._vendor.rich.console import Group
+    from fetchcode.vcs.pip._vendor.rich.markdown import Markdown
+    from fetchcode.vcs.pip._vendor.rich.panel import Panel
+    from fetchcode.vcs.pip._vendor.rich.syntax import Syntax
+    from fetchcode.vcs.pip._vendor.rich.table import Table
 
     table = Table(row_styles=["", "dim"])
 

--- a/src/fetchcode/vcs/pip/_vendor/truststore/_api.py
+++ b/src/fetchcode/vcs/pip/_vendor/truststore/_api.py
@@ -22,7 +22,7 @@ else:
     from ._openssl import _configure_context, _verify_peercerts_impl
 
 if typing.TYPE_CHECKING:
-    from pip._vendor.typing_extensions import Buffer
+    from fetchcode.vcs.pip._vendor.typing_extensions import Buffer
 
 # From typeshed/stdlib/ssl.pyi
 _StrOrBytesPath: typing.TypeAlias = str | bytes | os.PathLike[str] | os.PathLike[bytes]

--- a/src/fetchcode/vcs/pip/_vendor/typing_extensions.py
+++ b/src/fetchcode/vcs/pip/_vendor/typing_extensions.py
@@ -2096,7 +2096,7 @@ else:
 
         Example::
 
-          from pip._vendor.typing_extensions import LiteralString
+          from fetchcode.vcs.pip._vendor.typing_extensions import LiteralString
 
           def query(sql: LiteralString) -> ...:
               ...
@@ -2141,7 +2141,7 @@ else:
         This can be used to define a function that should never be
         called, or a function that never returns::
 
-            from pip._vendor.typing_extensions import Never
+            from fetchcode.vcs.pip._vendor.typing_extensions import Never
 
             def never_call_me(arg: Never) -> None:
                 pass
@@ -2616,7 +2616,7 @@ else:  # <=3.11
 
         Example:
 
-            from pip._vendor.typing_extensions import dataclass_transform
+            from fetchcode.vcs.pip._vendor.typing_extensions import dataclass_transform
 
             _T = TypeVar("_T")
 
@@ -3291,7 +3291,7 @@ else:
         Examples::
 
             from typing import TypeVar, Generic
-            from pip._vendor.typing_extensions import NamedTuple, TypedDict
+            from fetchcode.vcs.pip._vendor.typing_extensions import NamedTuple, TypedDict
 
             T = TypeVar("T")
             class Foo(Generic[T]): ...

--- a/src/fetchcode/vcs/pip/_vendor/urllib3/contrib/appengine.py
+++ b/src/fetchcode/vcs/pip/_vendor/urllib3/contrib/appengine.py
@@ -4,8 +4,8 @@ This module provides a pool manager that uses Google App Engine's
 
 Example usage::
 
-    from pip._vendor.urllib3 import PoolManager
-    from pip._vendor.urllib3.contrib.appengine import AppEngineManager, is_appengine_sandbox
+    from fetchcode.vcs.pip._vendor.urllib3 import PoolManager
+    from fetchcode.vcs.pip._vendor.urllib3.contrib.appengine import AppEngineManager, is_appengine_sandbox
 
     if is_appengine_sandbox():
         # AppEngineManager uses AppEngine's URLFetch API behind the scenes

--- a/src/fetchcode/vcs/pip/_vendor/urllib3/contrib/pyopenssl.py
+++ b/src/fetchcode/vcs/pip/_vendor/urllib3/contrib/pyopenssl.py
@@ -197,7 +197,7 @@ def _dnsname_to_stdlib(name):
         that we can't just safely call `idna.encode`: it can explode for
         wildcard names. This avoids that problem.
         """
-        from pip._vendor import idna
+        from fetchcode.vcs.pip._vendor import idna
 
         try:
             for prefix in [u"*.", u"."]:

--- a/src/fetchcode/vcs/pip/_vendor/urllib3/util/ssl_.py
+++ b/src/fetchcode/vcs/pip/_vendor/urllib3/util/ssl_.py
@@ -260,7 +260,7 @@ def create_urllib3_context(
 
     If you wish to enable SSLv3, you can do::
 
-        from pip._vendor.urllib3.util import ssl_
+        from fetchcode.vcs.pip._vendor.urllib3.util import ssl_
         context = ssl_.create_urllib3_context()
         context.options &= ~ssl_.OP_NO_SSLv3
 

--- a/src/fetchcode/vcs/pip/_vendor/urllib3/util/url.py
+++ b/src/fetchcode/vcs/pip/_vendor/urllib3/util/url.py
@@ -305,7 +305,7 @@ def _normalize_host(host, scheme):
 def _idna_encode(name):
     if name and any(ord(x) >= 128 for x in name):
         try:
-            from pip._vendor import idna
+            from fetchcode.vcs.pip._vendor import idna
         except ImportError:
             six.raise_from(
                 LocationParseError("Unable to parse URL without the 'idna' module"),

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -22,7 +22,7 @@ from fetchcode.vcs import fetch_via_vcs
 from fetchcode.vcs.pip._internal.vcs import vcs
 
 
-def obtain(dest, url):
+def obtain(dest, url, verbosity):
     pass
 
 


### PR DESCRIPTION
- Fix the import for the vendored pip
- Supply verbosity while calling the new `VersionControl.obtain`
- Add a CHANGELOG for the v0.6.0 release