### PR TITLE
Keep GitHub package tags with no release date

### DIFF
--- a/src/fetchcode/package_util.py
+++ b/src/fetchcode/package_util.py
@@ -131,7 +131,7 @@ def _get_github_packages(purl, version_regex, ignored_tag_regex, default_package
 
         download_url = archive_download_url.format(org=purl.namespace, name=purl.name, tag_name=tag)
 
-        date = date.strftime("%Y-%m-%dT%H:%M:%S")
+        date = date.strftime("%Y-%m-%dT%H:%M:%S") if date else None
         package_dict.update(
             {
                 "download_url": download_url,

--- a/tests/test_github_missing_date.py
+++ b/tests/test_github_missing_date.py
@@ -1,0 +1,15 @@
+from packageurl import PackageURL
+
+from fetchcode import package_util
+from fetchcode.packagedcode_models import Package
+
+
+def test_github_package_without_release_date(monkeypatch):
+    monkeypatch.setattr(
+        package_util.utils, "fetch_github_tags_gql", lambda purl: [("v1.2.3", None)]
+    )
+    purl = PackageURL("github", "example", "project")
+    packages = list(package_util.get_github_packages(purl, None, None, Package(**purl.to_dict())))
+    assert len(packages) == 1
+    assert packages[0].version == "1.2.3"
+    assert packages[0].release_date is None

--- a/tests/test_github_missing_date.py
+++ b/tests/test_github_missing_date.py
@@ -1,3 +1,19 @@
+# fetchcode is a free software tool from nexB Inc. and others.
+# Visit https://github.com/aboutcode-org/fetchcode for support and download.
+
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# http://nexb.com and http://aboutcode.org
+
+# This software is licensed under the Apache License version 2.0.
+
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at:
+# http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 from packageurl import PackageURL
 
 from fetchcode import package_util


### PR DESCRIPTION
The GitHub tag helper can return `None` for an unavailable or unparseable commit date, but package conversion unconditionally calls `strftime()`. Preserve the package with an unset release date instead of crashing.

Adds a regression test with a tag whose date is unavailable.
