### PR TITLE
Match CocoaPods names exactly when reading version lists

### DIFF
--- a/src/fetchcode/package_util.py
+++ b/src/fetchcode/package_util.py
@@ -297,7 +297,7 @@ def get_cocoapod_tags(spec, name):
         data = response.strip()
         for line in data.splitlines():
             line = line.strip()
-            if line.startswith(name):
+            if line.startswith(name + "/"):
                 data_list = line.split("/")
                 if data_list[0] == name:
                     data_list.pop(0)

--- a/tests/test_cocoapods_tag_lookup.py
+++ b/tests/test_cocoapods_tag_lookup.py
@@ -1,3 +1,19 @@
+# fetchcode is a free software tool from nexB Inc. and others.
+# Visit https://github.com/aboutcode-org/fetchcode for support and download.
+
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# http://nexb.com and http://aboutcode.org
+
+# This software is licensed under the Apache License version 2.0.
+
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at:
+# http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 from fetchcode.package_util import get_cocoapod_tags
 
 

--- a/tests/test_cocoapods_tag_lookup.py
+++ b/tests/test_cocoapods_tag_lookup.py
@@ -1,0 +1,13 @@
+from fetchcode.package_util import get_cocoapod_tags
+
+
+def test_cocoapod_tags_skip_packages_with_same_prefix(monkeypatch):
+    monkeypatch.setattr(
+        "fetchcode.utils.get_text_response", lambda url: "FooBar/9.0\nFoo/1.0/2.0\n"
+    )
+    assert get_cocoapod_tags("https://example.com/versions", "Foo") == ["1.0", "2.0"]
+
+
+def test_cocoapod_tags_return_none_when_only_prefix_matches(monkeypatch):
+    monkeypatch.setattr("fetchcode.utils.get_text_response", lambda url: "FooBar/9.0\n")
+    assert get_cocoapod_tags("https://example.com/versions", "Foo") is None


### PR DESCRIPTION
Looking up `Foo` can return the versions of `FooBar` because the lookup only checks the name prefix. Include the field separator in the match so only the requested pod is selected.

Adds tests with an overlapping name and with no exact match.
