### PR TITLE
Use CocoaPods source tags without changing package versions

### DIFF
--- a/src/fetchcode/package_util.py
+++ b/src/fetchcode/package_util.py
@@ -362,10 +362,8 @@ def construct_cocoapods_package(
         if git_url and not http_url:
             if git_url.endswith(".git") and git_url.startswith("https://github.com/"):
                 gh_path = git_url[:-4]
-                github_tag = source.get("tag")
-                if github_tag and github_tag.startswith("v"):
-                    tag = github_tag
-                download_url = f"{gh_path}/archive/refs/tags/{tag}.tar.gz"
+                github_tag = source.get("tag") or tag
+                download_url = f"{gh_path}/archive/refs/tags/{github_tag}.tar.gz"
                 vcs_url = git_url
         elif git_url:
             vcs_url = git_url

--- a/tests/test_cocoapods_source_tags.py
+++ b/tests/test_cocoapods_source_tags.py
@@ -1,0 +1,24 @@
+import pytest
+from packageurl import PackageURL
+
+from fetchcode import package_util
+
+
+@pytest.mark.parametrize("source_tag", ["v1.2.3", "release-1_2_3", None])
+def test_cocoapods_source_tag_preserves_package_version(monkeypatch, source_tag):
+    monkeypatch.setattr(
+        package_util.utils,
+        "get_response",
+        lambda url: {
+            "source": {"git": "https://github.com/example/Example.git", "tag": source_tag},
+        },
+    )
+    purl = PackageURL(type="cocoapods", name="Example", version="1.2.3")
+    package = package_util.construct_cocoapods_package(
+        purl, "Example", "a/b/c", "https://cocoapods.org/pods/Example", None, None, "1.2.3"
+    )
+    assert package.version == "1.2.3"
+    assert (
+        package.download_url
+        == f"https://github.com/example/Example/archive/refs/tags/{source_tag or '1.2.3'}.tar.gz"
+    )

--- a/tests/test_cocoapods_source_tags.py
+++ b/tests/test_cocoapods_source_tags.py
@@ -1,3 +1,19 @@
+# fetchcode is a free software tool from nexB Inc. and others.
+# Visit https://github.com/aboutcode-org/fetchcode for support and download.
+
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# http://nexb.com and http://aboutcode.org
+
+# This software is licensed under the Apache License version 2.0.
+
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at:
+# http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import pytest
 from packageurl import PackageURL
 


### PR DESCRIPTION
Use the podspec's source tag when constructing GitHub archive URLs, including tags without a `v` prefix. Keep that tag separate from the CocoaPods package version.

Adds tests for prefixed, custom, and omitted source tags.
