### PR TITLE
Handle GitHub tags whose targets have no commit date

### DIFF
--- a/src/fetchcode/utils.py
+++ b/src/fetchcode/utils.py
@@ -34,7 +34,7 @@ def fetch_github_tags_gql(purl):
 
         # in case the tag is a signed tag, then the commit info is in target['target']
         if "committedDate" not in target:
-            target = target["target"]
+            target = target.get("target") or {}
 
         committed_date = target.get("committedDate")
         release_date = None

--- a/tests/test_github_tag_targets.py
+++ b/tests/test_github_tag_targets.py
@@ -1,0 +1,11 @@
+import pytest
+
+from fetchcode import utils
+
+
+@pytest.mark.parametrize("target", [{}, {"target": {}}, {"target": None}])
+def test_tags_without_commit_targets(monkeypatch, target):
+    monkeypatch.setattr(
+        utils, "fetch_github_tag_nodes", lambda purl: [{"name": "v1", "target": target}]
+    )
+    assert list(utils.fetch_github_tags_gql(None)) == [("v1", None)]

--- a/tests/test_github_tag_targets.py
+++ b/tests/test_github_tag_targets.py
@@ -1,3 +1,19 @@
+# fetchcode is a free software tool from nexB Inc. and others.
+# Visit https://github.com/aboutcode-org/fetchcode for support and download.
+
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# http://nexb.com and http://aboutcode.org
+
+# This software is licensed under the Apache License version 2.0.
+
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at:
+# http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import pytest
 
 from fetchcode import utils


### PR DESCRIPTION
The GraphQL tag query can return an empty target object for tags pointing to non-commit objects. Keep these tag names with an unknown date instead of raising `KeyError`.

Adds regressions for direct and annotated targets without commit data.
