### PR TITLE
Handle absent CocoaPods versions and homepage metadata

### DIFF
--- a/src/fetchcode/package.py
+++ b/src/fetchcode/package.py
@@ -379,7 +379,7 @@ def get_cocoapods_data_from_purl(purl):
     hashed_path_underscore = hashed_path.replace("/", "_")
     file_prefix = "all_pods_versions_"
     spec = f"{api}/{file_prefix}{hashed_path_underscore}.txt"
-    data_list = get_cocoapod_tags(spec, name)
+    data_list = get_cocoapod_tags(spec, name) or []
 
     for tag in data_list:
         version_purl = PackageURL(type=purl.type, name=name, version=tag)
@@ -391,7 +391,7 @@ def get_cocoapods_data_from_purl(purl):
         base_url = "https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs"
         podspec_api_url = f"{base_url}/{hashed_path}/{name}/{tag}/{name}.podspec.json"
         podspec_api_response = get_response(podspec_api_url)
-        podspec_homepage = podspec_api_response.get("homepage")
+        podspec_homepage = podspec_api_response.get("homepage") or ""
 
         if podspec_homepage.startswith("https://github.com/"):
             podspec_homepage_remove_gh_prefix = podspec_homepage.replace("https://github.com/", "")

--- a/tests/test_cocoapods_missing_metadata.py
+++ b/tests/test_cocoapods_missing_metadata.py
@@ -1,0 +1,30 @@
+# fetchcode is a free software tool from nexB Inc. and others.
+# Visit https://github.com/aboutcode-org/fetchcode for support and download.
+
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# http://nexb.com and http://aboutcode.org
+
+# This software is licensed under the Apache License version 2.0.
+
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at:
+# http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from fetchcode import package
+
+
+def test_cocoapods_with_no_versions(monkeypatch):
+    monkeypatch.setattr(package, "get_cocoapod_tags", lambda *args: None)
+    assert list(package.get_cocoapods_data_from_purl("pkg:cocoapods/Example")) == []
+
+
+def test_cocoapods_without_homepage(monkeypatch):
+    monkeypatch.setattr(package, "get_cocoapod_tags", lambda *args: ["1.0"])
+    monkeypatch.setattr(package, "get_response", lambda url: {})
+    sentinel = object()
+    monkeypatch.setattr(package, "construct_cocoapods_package", lambda *args: sentinel)
+    assert list(package.get_cocoapods_data_from_purl("pkg:cocoapods/Example")) == [sentinel]


### PR DESCRIPTION
Missing CocoaPods version lists raise `TypeError`, and an omitted homepage raises `AttributeError`. Treat a missing list as empty and allow package construction without homepage metadata.

Adds regressions for both responses.
