### PR TITLE
Preserve npm scopes when fetching package metadata

### DIFF
--- a/src/fetchcode/package.py
+++ b/src/fetchcode/package.py
@@ -122,7 +122,8 @@ def get_npm_data_from_purl(purl):
     base_path = "http://registry.npmjs.org"
     name = purl.name
     version = purl.version
-    api_url = f"{base_path}/{name}"
+    full_name = f"{purl.namespace}/{name}" if purl.namespace else name
+    api_url = f"{base_path}/{full_name}"
 
     response = get_response(api_url)
     vcs_data = response.get("repository") or {}
@@ -136,7 +137,9 @@ def get_npm_data_from_purl(purl):
     versions = response.get("versions", [])
     for num in versions:
         version = versions[num]
-        version_purl = PackageURL(type=purl.type, name=name, version=version.get("version"))
+        version_purl = PackageURL(
+            type=purl.type, namespace=purl.namespace, name=name, version=version.get("version")
+        )
         repository = version.get("repository") or {}
         bugs = response.get("bugs") or {}
         dist = version.get("dist") or {}

--- a/tests/test_npm_metadata_scope.py
+++ b/tests/test_npm_metadata_scope.py
@@ -1,0 +1,36 @@
+# fetchcode is a free software tool from nexB Inc. and others.
+# Visit https://github.com/aboutcode-org/fetchcode for support and download.
+
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# http://nexb.com and http://aboutcode.org
+
+# This software is licensed under the Apache License version 2.0.
+
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at:
+# http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import pytest
+
+from fetchcode import package
+
+
+@pytest.mark.parametrize(
+    "purl,registry_name",
+    [("pkg:npm/%40scope/example@1.0", "@scope/example"), ("pkg:npm/example@1.0", "example")],
+)
+def test_npm_metadata_preserves_scope(monkeypatch, purl, registry_name):
+    urls = []
+
+    def response(url):
+        urls.append(url)
+        return {"versions": {"1.0": {"version": "1.0"}}}
+
+    monkeypatch.setattr(package, "get_response", response)
+    result = list(package.get_npm_data_from_purl(purl))
+    assert urls == ["http://registry.npmjs.org/" + registry_name]
+    assert result[0].purl == purl


### PR DESCRIPTION
The package metadata fetcher drops the namespace from scoped npm packages, querying the unscoped package and returning an unscoped package URL. Include the scope in both places.

Adds scoped and unscoped regressions. The separate version-list fetcher already handles scopes.
