### PR TITLE
Filter Composer development versions by their version value

### DIFF
--- a/src/fetchcode/package_versions.py
+++ b/src/fetchcode/package_versions.py
@@ -409,15 +409,12 @@ def fetch_version_info(version_info: str, escaped_pkg: str) -> Optional[PackageV
 
 def composer_extract_versions(resp: dict, pkg: str) -> Iterable[PackageVersion]:
     for item in get_item(resp, "packages", pkg) or []:
-        if "dev-" in item:
-            continue
-
         # This if statement ensures, that all_versions contains only released versions
         # See https://github.com/composer/composer/blob/44a4429978d1b3c6223277b875762b2930e83e8c/doc/articles/versions.md#tags  # nopep8
         # for explanation of removing 'v'
         time = item.get("time")
         version = item.get("version")
-        if not version:
+        if not version or version.startswith("dev-") or version.endswith("-dev"):
             continue
         yield PackageVersion(
             value=cleaned_version(version),

--- a/tests/test_composer_dev_versions.py
+++ b/tests/test_composer_dev_versions.py
@@ -1,0 +1,35 @@
+# fetchcode is a free software tool from nexB Inc. and others.
+# Visit https://github.com/aboutcode-org/fetchcode for support and download.
+
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# http://nexb.com and http://aboutcode.org
+
+# This software is licensed under the Apache License version 2.0.
+
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at:
+# http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from fetchcode.package_versions import composer_extract_versions
+
+
+def test_composer_filters_development_versions():
+    response = {
+        "packages": {
+            "vendor/example": [
+                {"version": "dev-main"},
+                {"version": "1.x-dev"},
+                {"version": "v1.2.3"},
+                {"version": "1.3.0-beta1"},
+                {},
+            ]
+        }
+    }
+    assert [item.value for item in composer_extract_versions(response, "vendor/example")] == [
+        "1.2.3",
+        "1.3.0-beta1",
+    ]


### PR DESCRIPTION
The development-version filter checks dictionary keys instead of the version string, so development branches are reported as releases. Check `dev-` prefixes and `-dev` suffixes on the version value.

Adds branch, numeric development, stable, and prerelease coverage.
