### PR TITLE
Fetch NuGet registration pages when versions are not inlined

### DIFF
--- a/src/fetchcode/package_versions.py
+++ b/src/fetchcode/package_versions.py
@@ -456,6 +456,8 @@ def cleaned_version(version):
 
 def nuget_extract_versions(response: dict) -> Iterable[PackageVersion]:
     for entry_group in response.get("items") or []:
+        if "items" not in entry_group and entry_group.get("@id"):
+            entry_group = get_response(url=entry_group["@id"]) or {}
         for entry in entry_group.get("items") or []:
             catalog_entry = entry.get("catalogEntry") or {}
             version = catalog_entry.get("version")

--- a/tests/test_nuget_registration_pages.py
+++ b/tests/test_nuget_registration_pages.py
@@ -1,0 +1,40 @@
+# fetchcode is a free software tool from nexB Inc. and others.
+# Visit https://github.com/aboutcode-org/fetchcode for support and download.
+
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# http://nexb.com and http://aboutcode.org
+
+# This software is licensed under the Apache License version 2.0.
+
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at:
+# http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from fetchcode import package_versions
+
+
+def test_nuget_fetches_external_registration_pages(monkeypatch):
+    calls = []
+
+    def response(url):
+        calls.append(url)
+        return {
+            "items": [{"catalogEntry": {"version": "2.0", "published": "2024-01-01T00:00:00Z"}}]
+        }
+
+    monkeypatch.setattr(package_versions, "get_response", response)
+    index = {
+        "items": [
+            {"@id": "https://example.org/inline", "items": [{"catalogEntry": {"version": "1.0"}}]},
+            {"@id": "https://example.org/page2"},
+            {"@id": "https://example.org/empty", "items": []},
+        ]
+    }
+    versions = list(package_versions.nuget_extract_versions(index))
+    assert [version.value for version in versions] == ["1.0", "2.0"]
+    assert calls == ["https://example.org/page2"]
+    assert versions[1].release_date.isoformat() == "2024-01-01T00:00:00+00:00"


### PR DESCRIPTION
NuGet registration indexes can link to pages instead of inlining their versions. Follow a page's `@id` when `items` is absent so packages with larger release histories are included.

Adds mixed inline/external page coverage and checks that inline pages are not fetched again. This follows the [NuGet registration API](https://learn.microsoft.com/en-us/nuget/api/registration-base-url-resource).
